### PR TITLE
Use native `hashedindex` stemmer support

### DIFF
--- a/scripts/search.py
+++ b/scripts/search.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 
-from hashedindex import HashedIndex, textparser
+from hashedindex import HashedIndex
+from hashedindex.textparser import word_tokenize
 from snowballstemmer import stemmer
-
 
 
 class SnowballStemmer():
@@ -20,7 +20,7 @@ def tokenize(doc, stopwords=None):
     stemmer = SnowballStemmer()
 
     for ngrams in range(len(words), 0, -1):
-        for term in textparser.word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
+        for term in word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
             yield term
 
 

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -3,18 +3,25 @@ from collections import defaultdict
 from hashedindex import HashedIndex, textparser
 from snowballstemmer import stemmer
 
-stemmer_en = stemmer('english')
+
+
+class SnowballStemmer():
+
+    stemmer_en = stemmer('english')
+
+    def stem(self, x):
+        return self.stemmer_en.stemWord(x)
 
 
 def tokenize(doc, stopwords=None):
     stopwords = stopwords or []
     words = doc.split(' ')
-    # TODO: Push stemming into upstream hashedindex library
-    words = stemmer_en.stemWords(words)
     doc = ' '.join(words)
+    stemmer = SnowballStemmer()
+
     for ngrams in range(len(words), 0, -1):
-        for term in textparser.word_tokenize(doc, stopwords, ngrams):
-            yield tuple(stemmer_en.stemWords(term))
+        for term in textparser.word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
+            yield term
 
 
 def add_to_search_index(index, doc_id, doc, stopwords):

--- a/scripts/search.py
+++ b/scripts/search.py
@@ -15,11 +15,10 @@ class SnowballStemmer():
 
 def tokenize(doc, stopwords=None):
     stopwords = stopwords or []
-    words = doc.split(' ')
-    doc = ' '.join(words)
     stemmer = SnowballStemmer()
 
-    for ngrams in range(len(words), 0, -1):
+    word_count = len(doc.split(' '))
+    for ngrams in range(word_count, 0, -1):
         for term in word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
             yield term
 


### PR DESCRIPTION
With https://github.com/MichaelAquilina/hashedindex/pull/12 merged and released, the ingredient tokenization code can be migrated to use the native `stemmer` support provided by `hashedindex`.