### PR TITLE
Refactor: store parent_ids instead of parent references

### DIFF
--- a/scripts/hierarchy.py
+++ b/scripts/hierarchy.py
@@ -48,7 +48,7 @@ graph.filter_products()
 def node_explorer(graph, node):
     for child_id in node.children:
         child = graph.products_by_id[child_id]
-        if child.primary_parent == node:
+        if child.parent_id == node.id:
             yield child
             for child in node_explorer(graph, child):
                 yield child

--- a/scripts/models/product.py
+++ b/scripts/models/product.py
@@ -21,7 +21,7 @@ class Product(object):
         self.depth = None
         self.children = []
         self.parents = []
-        self.primary_parent = None
+        self.parent_id = None
         self.stopwords = []
 
     def __add__(self, other):
@@ -38,12 +38,8 @@ class Product(object):
         if tree_rendering:
             data.update({
                 'id': self.id,
+                'parent_id': self.parent_id,
                 'depth': self.depth
-            })
-
-        if self.primary_parent:
-            data.update({
-                'parent_id': self.primary_parent.id
             })
 
         return '  ' * (self.depth or 0) + json.dumps(data, ensure_ascii=False)
@@ -72,7 +68,7 @@ class Product(object):
     def content(self):
         return ' '.join(self.tokens)
 
-    def calculate_depth(self, path=None):
+    def calculate_depth(self, graph, path=None):
         if self.depth is not None:
             return self.depth
 
@@ -83,8 +79,9 @@ class Product(object):
         path.append(self.id)
 
         depth = 0
-        if self.primary_parent:
-            depth = self.primary_parent.calculate_depth(path) + 1
+        if self.parent_id:
+            parent = graph.products_by_id[self.parent_id]
+            depth = parent.calculate_depth(graph, path) + 1
 
         self.depth = depth
         return depth

--- a/scripts/models/product_graph.py
+++ b/scripts/models/product_graph.py
@@ -116,11 +116,12 @@ class ProductGraph(object):
                     primary_parent = parent
                 if len(parent.tokens) > len(primary_parent.tokens):
                     primary_parent = parent
-            product.primary_parent = primary_parent
+            if primary_parent:
+                product.parent_id = primary_parent.id
 
     def calculate_depth(self):
         for product in self.products_by_id.values():
-            product.calculate_depth()
+            product.calculate_depth(self)
 
     @property
     def roots(self):

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,9 +1,17 @@
 from scripts.models.product import Product
 
 
+class MockGraph():
+
+    def __init__(self, products):
+        self.products = products
+        self.products_by_id = {product.id: product for product in products}
+
+
 def generate_product(name, parent=None):
     product = Product(name=name, frequency=1)
-    product.primary_parent = parent
+    if parent:
+        product.parent_id = parent.id
     return product
 
 
@@ -13,7 +21,8 @@ def test_calculate_depth():
     a3 = generate_product(name='a3', parent=a1)
     a4 = generate_product(name='a4', parent=a2)
 
-    [a.calculate_depth() for a in [a1, a2, a3, a4]]
+    graph = MockGraph([a1, a2, a3, a4])
+    [a.calculate_depth(graph) for a in graph.products]
 
     assert a1.depth == 0
     assert a2.depth == 1
@@ -28,9 +37,10 @@ def test_calculate_depth_avoids_loop():
     a4 = generate_product(name='a4', parent=a2)
 
     # Introduce a loop to the graph
-    a1.primary_parent = a4
+    a1.parent_id = a4.id
 
-    [a.calculate_depth() for a in [a1, a2, a3, a4]]
+    graph = MockGraph([a1, a2, a3, a4])
+    [a.calculate_depth(graph) for a in graph.products]
 
     assert a1.depth == 2
     assert a2.depth == 0

--- a/tests/test_product_graph.py
+++ b/tests/test_product_graph.py
@@ -30,8 +30,8 @@ def test_tofu_hierarchy():
 
     assert len(roots) == 1
     assert tofu in roots
-    assert firm_tofu.primary_parent == tofu
-    assert soft_tofu.primary_parent == tofu
+    assert firm_tofu.parent_id == tofu.id
+    assert soft_tofu.parent_id == tofu.id
 
 
 def test_bananas_common_root():
@@ -62,7 +62,7 @@ def test_bell_pepper_categorization():
     roots = generate_hierarchy(products=all_products)
 
     assert len(roots) == 1
-    assert len([p for p in all_products if p.primary_parent == roots[0]]) == 2
+    assert len([p for p in all_products if p.parent_id == roots[0].id]) == 2
 
 
 def test_red_bell_pepper_parent_assignment():
@@ -87,5 +87,5 @@ def test_red_bell_pepper_parent_assignment():
     red_bell_pepper_diced = graph.products_by_id[red_bell_pepper_diced.id]
 
     assert len(roots) == 1
-    assert red_bell_pepper.primary_parent == roots[0]
-    assert red_bell_pepper_diced.primary_parent == roots[0]
+    assert red_bell_pepper.parent_id == roots[0].id
+    assert red_bell_pepper_diced.parent_id == roots[0].id


### PR DESCRIPTION
This will make serialization and deserialization of the product hierarchy much more straightforward.