### PR TITLE
Include ancestors in product metadata

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -74,11 +74,18 @@ def test_content_rendering():
 
 
 def test_metadata():
-    a1 = generate_product(name='black olives')
+    a1 = generate_product(name='olives')
+    a2 = generate_product(name='black olives', parent=a1)
+    a3 = generate_product(name='greek black olives', parent=a2)
 
-    assert a1.metadata['singular'] == 'black olife'
-    assert a1.metadata['plural'] == 'black olives'
-    assert a1.metadata['is_plural'] is True
+    graph = MockGraph([a1, a2, a3])
+    metadata = a3.get_metadata(graph)
+
+    # TODO: re-enable after https://github.com/jazzband/inflect/pull/95 merged
+    # assert metadata['singular'] == 'greek black olive'
+    assert metadata['plural'] == 'greek black olives'
+    assert metadata['is_plural'] is True
+    assert 'olives' in metadata['ancestors']
 
 
 def product_categories():

--- a/web/app.py
+++ b/web/app.py
@@ -67,9 +67,14 @@ def query():
                 products[doc_id] = candidate
                 scores[doc_id] = score
 
+    # Build per-product result metadata
+    metadata = defaultdict(lambda: None)
+    for doc_id, product in products.items():
+        metadata[doc_id] = product.get_metadata(app.graph)
+
     return jsonify({
         'results': {
-            description: products[i].metadata if i in products else None
-            for i, description in enumerate(descriptions)
+            description: metadata[doc_id]
+            for doc_id, description in enumerate(descriptions)
         }
     })

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -80,8 +80,7 @@ class Product(object):
         self.depth = depth
         return depth
 
-    @property
-    def metadata(self):
+    def get_metadata(self, graph):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name
         plural = Product.inflector.plural_noun(singular)
@@ -94,7 +93,17 @@ class Product(object):
             'plural': plural,
             'category': self.category,
             'contents': self.contents,
+            'ancestors': [ancestor.name for ancestor in self.ancestry(graph)],
         }
+
+    def ancestry(self, graph):
+        if not self.parent_id:
+            return
+        parent = graph.products_by_id.get(self.parent_id)
+        if parent:
+            yield parent
+            for ancestor in parent.ancestry(graph):
+                yield ancestor
 
     @property
     def category(self):


### PR DESCRIPTION
This is a stepping stone towards enabling queries on a top-level ingredient (such as `tofu`) to additionally match on recipes which include  descendents (such as `firm tofu` or `soft tofu`).