### PR TITLE
Improve liquid smoke handling

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -10,11 +10,21 @@ class MockGraph():
         self.products_by_id = {product.id: product for product in products}
 
 
-def generate_product(name, parent=None):
-    product = Product(name=name, frequency=1)
+def generate_product(name, parent=None, frequency=1):
+    product = Product(name=name, frequency=frequency)
     if parent:
         product.parent_id = parent.id
     return product
+
+
+def test_merge_products():
+    a1 = generate_product(name='hickory liquid smoke', frequency=2)
+    a2 = generate_product(name='liquid smoke', frequency=10)
+
+    a1 += a2
+
+    assert a1.frequency == 12
+    assert a1.name == 'liquid smoke'
 
 
 def test_calculate_depth():

--- a/web/data/clear-words.txt
+++ b/web/data/clear-words.txt
@@ -12,4 +12,5 @@ baking
 confectioners
 powder
 ranch
+smoke
 sour

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -19,6 +19,8 @@ class Product(object):
         self.stopwords = []
 
     def __add__(self, other):
+        name = self.name if len(self.name) < len(other.name) else other.name
+        self.name = name
         self.frequency += other.frequency
         return self
 


### PR DESCRIPTION
The term `smoke` has been categorized as a stop-word by the ingredient ingestion process; this changeset adds it to the list of `clear-words` so that it can be considered a valid product name token.

Fixing this highlighted that during product merges (implemented via the Python [add](https://github.com/openculinary/knowledge-graph/blob/0cb757a29815d37722c71a6a0f8219d9555c9028/web/models/product.py#L21-L23) operator on the `Product` class), the winning product `name` was arbitrary; this change adds a rule which prefers the shorter production description, so that a merge of `hickory liquid smoke` and `liquid smoke` would pick the latter product name for the merged result.

Resolves #7 