### PR TITLE
Singularize product contents

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -135,6 +135,13 @@ def test_chicken_exclusion_contents():
         # assert 'meat' in contents
 
 
+def test_contents_singularization():
+    product = generate_product(name=f'mushrooms')
+
+    assert 'mushroom' in product.contents
+    assert 'mushrooms' not in product.contents
+
+
 @pytest.mark.parametrize('name,category', product_categories().items())
 def test_product_categories(name, category):
     product = generate_product(name=name)

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -109,6 +109,19 @@ class Product(object):
 
     @property
     def category(self):
+        content_categories = {
+            'banana': 'fruit_and_veg',
+            'berry': 'fruit_and_veg',
+            'berries': 'fruit_and_veg',
+            'garlic': 'fruit_and_veg',
+            'onion': 'fruit_and_veg',
+            'tomato': 'fruit_and_veg',
+
+            'ketchup': 'oil_and_vinegar_and_condiments',
+            'oil': 'oil_and_vinegar_and_condiments',
+            'soy sauce': 'oil_and_vinegar_and_condiments',
+            'vinegar': 'oil_and_vinegar_and_condiments',
+        }
         category_graph = {
             'bread': 'Bakery',
             'dairy': 'Dairy',
@@ -121,6 +134,10 @@ class Product(object):
         for content in self.contents:
             if content in category_graph:
                 return category_graph[content]
+        for content in content_categories:
+            if content in self.name.split(' '):
+                if content_categories[content] in category_graph:
+                    return category_graph[content_categories[content]]
 
     @property
     def contents(self):
@@ -135,23 +152,6 @@ class Product(object):
             'yoghurt': 'dairy',
             'yogurt': 'dairy',
 
-            'all-purpose flour': 'dry_goods',
-            'baking powder': 'dry_goods',
-            'black pepper': 'dry_goods',
-            'brown sugar': 'dry_goods',
-            'salt': 'dry_goods',
-            'salt and pepper': 'dry_goods',
-            'sugar': 'dry_goods',
-            'vanilla extract': 'dry_goods',
-            'white sugar': 'dry_goods',
-
-            'banana': 'fruit_and_veg',
-            'berry': 'fruit_and_veg',
-            'berries': 'fruit_and_veg',
-            'garlic': 'fruit_and_veg',
-            'onion': 'fruit_and_veg',
-            'tomato': 'fruit_and_veg',
-
             'bacon': 'meat',
             'beef': 'meat',
             'chicken': 'meat',
@@ -162,11 +162,6 @@ class Product(object):
             'steak': 'meat',
             'turkey': 'meat',
             'venison': 'meat',
-
-            'ketchup': 'oil_and_vinegar_and_condiments',
-            'oil': 'oil_and_vinegar_and_condiments',
-            'soy sauce': 'oil_and_vinegar_and_condiments',
-            'vinegar': 'oil_and_vinegar_and_condiments',
         }
         exclusion_graph = {
             'meat': ['stock', 'broth', 'tomato', 'bouillon', 'soup', 'eggs'],
@@ -174,15 +169,17 @@ class Product(object):
             'fruit_and_veg': ['green tomato'],
         }
 
-        contents = {self.name}
+        contents = {Product.inflector.singular_noun(self.name) or self.name}
         for content in content_graph:
             if content in self.name.split():
                 excluded = False
-                for field in [content, content_graph[content]]:
+                fields = [content, content_graph[content]]
+                for field in fields:
                     for excluded_term in exclusion_graph.get(field, []):
                         excluded = excluded or excluded_term in self.name
                 if excluded:
                     continue
-                contents.add(content)
-                contents.add(content_graph[content])
+                for field in fields:
+                    singular = Product.inflector.singular_noun(field) or field
+                    contents.add(singular)
         return list(contents)


### PR DESCRIPTION
The `contents` field in the recipe search engine is queried based on the singularized version of each ingredient named in the query.

This changeset updates the logic which produces each product's `contents` metadata to ensure that all entries are singularized to match that expectation.