### PR TITLE
Return category identifiers instead of en-language names

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -100,10 +100,10 @@ def test_metadata():
 
 def product_categories():
     return {
-        'olive oil': 'Oil, Vinegar & Condiments',
-        'canola oil': 'Oil, Vinegar & Condiments',
-        'white wine vinegar': 'Oil, Vinegar & Condiments',
-        'ketchup': 'Oil, Vinegar & Condiments',
+        'olive oil': 'oil_and_vinegar_and_condiments',
+        'canola oil': 'oil_and_vinegar_and_condiments',
+        'white wine vinegar': 'oil_and_vinegar_and_condiments',
+        'ketchup': 'oil_and_vinegar_and_condiments',
     }
 
 

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -110,6 +110,9 @@ class Product(object):
     @property
     def category(self):
         content_categories = {
+            'egg': 'dairy',
+            'milk': 'dairy',
+
             'banana': 'fruit_and_veg',
             'berry': 'fruit_and_veg',
             'berries': 'fruit_and_veg',
@@ -117,27 +120,28 @@ class Product(object):
             'onion': 'fruit_and_veg',
             'tomato': 'fruit_and_veg',
 
+            'meat': 'meat_and_deli',
+
             'ketchup': 'oil_and_vinegar_and_condiments',
             'oil': 'oil_and_vinegar_and_condiments',
             'soy sauce': 'oil_and_vinegar_and_condiments',
             'vinegar': 'oil_and_vinegar_and_condiments',
         }
-        category_graph = {
-            'bread': 'Bakery',
-            'dairy': 'Dairy',
-            'dry_goods': 'Dry Goods',
-            'fruit_and_veg': 'Fruit & Vegetables',
-            'egg': 'Dairy',
-            'meat': 'Meat',
-            'oil_and_vinegar_and_condiments': 'Oil, Vinegar & Condiments',
+        categories = {
+            'bread',
+            'dairy',
+            'dry_goods',
+            'fruit_and_veg',
+            'meat_and_deli',
+            'oil_and_vinegar_and_condiments',
         }
         for content in self.contents:
-            if content in category_graph:
-                return category_graph[content]
+            if content in categories:
+                return content
         for content in content_categories:
             if content in self.name.split(' '):
-                if content_categories[content] in category_graph:
-                    return category_graph[content_categories[content]]
+                if content_categories[content] in categories:
+                    return content_categories[content]
 
     @property
     def contents(self):


### PR DESCRIPTION
Relates to https://github.com/openculinary/frontend/issues/3

Now that the [frontend](https://www.github.com/openculinary/frontend) application has [international support](https://github.com/openculinary/frontend/pull/33), backend services should migrate to use identifiers instead of free-text language in their responses wherever possible.