### PR TITLE
Add support for ingredient byproducts

### DIFF
--- a/web/data/byproducts.txt
+++ b/web/data/byproducts.txt
@@ -1,0 +1,4 @@
+bouillon,stock
+broth,stock
+stock,stock
+vinegar,vinegar

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -17,6 +17,7 @@ class Product(object):
         self.children = []
         self.parents = []
         self.stopwords = []
+        self.domain = None
 
     def __add__(self, other):
         name = self.name if len(self.name) < len(other.name) else other.name
@@ -36,6 +37,7 @@ class Product(object):
         if include_hierarchy:
             data.update({
                 'id': self.id,
+                'domain': self.domain,
                 'parent_id': self.parent_id,
                 'depth': self.depth
             })

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -126,8 +126,12 @@ class ProductGraph(object):
             hits = execute_query(self.index, byproduct)
             for hit in hits:
                 child_id = hit['doc_id']
+
+                # The byproduct root (e.g. 'stock') may be found as a match;
+                # avoid assigning the root to itself as a parent
                 if child_id == parent_id:
                     continue
+
                 child = self.products_by_id[child_id]
                 child.domain = 'byproducts'
                 child.parents.append(parent.id)

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -118,13 +118,17 @@ class ProductGraph(object):
             if not parent_hits:
                 continue
 
-            parent = self.products_by_id.get(parent_hits[0]['doc_id'])
+            parent_id = parent_hits[0]['doc_id']
+            parent = self.products_by_id.get(parent_id)
             parent.domain = 'byproducts'
 
             # Find all of the byproducts the parent relates to
             hits = execute_query(self.index, byproduct)
             for hit in hits:
-                child = self.products_by_id[hit['doc_id']]
+                child_id = hit['doc_id']
+                if child_id == parent_id:
+                    continue
+                child = self.products_by_id[child_id]
                 child.domain = 'byproducts'
                 child.parents.append(parent.id)
                 parent.children.append(child.id)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Implements the proposed solution for ingredient 'byproducts' from #23.

### Briefly summarize the changes
1. Add an input `byproducts.txt` file that contains a mapping of ingredient terms to parent product names
1. Use the input file at ingredient-relationship-matching time to build the ingredient hierarchy

### How have the changes been tested?
1. Locally via `pipenv run python -m scripts.hierarchy --update`

**List any issues that this change relates to**
Relates to https://github.com/openculinary/api/issues/41.
Resolves #23.
