### PR TITLE
Add 'soy milk' to canonicalizations

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -4,6 +4,7 @@ from flask import Flask, jsonify, request
 
 from web.loader import (
     CACHE_PATHS,
+    canonicalize,
     retrieve_hierarchy,
     retrieve_stopwords,
 )
@@ -47,6 +48,7 @@ def find_product_candidates(descriptions):
 @app.route('/ingredients/query', methods=['POST'])
 def query():
     descriptions = request.form.getlist('descriptions[]')
+    descriptions = [canonicalize(description) for description in descriptions]
 
     # Build a local search index over the descriptions
     description_index = build_search_index()

--- a/web/data/canonicalizations.txt
+++ b/web/data/canonicalizations.txt
@@ -6,4 +6,5 @@ cinammon,cinnamon
 coriander,cilantro
 filet,fillet
 soya,soy
+soymilk,soy milk
 yoghurt,yogurt


### PR DESCRIPTION
### Briefly summarize the changes
1. Adds a mapping from 'soymilk' to 'soy milk' in the `canonicalizations.txt` file

### How have the changes been tested?
1. Locally via `pipenv run python -m scripts.hierarchy --update` and inspection of the resulting ingredient hierarchy (`hierarchy.json`)
2. Apply canonicalizations to `knowledge-graph` query input descriptions

**List any issues that this change relates to**
Fixes #21 
Fixes #26 