### PR TITLE
Add support for synonyms via SynonymAnalyzer

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -5,6 +5,7 @@ from web.search import (
     execute_exact_query,
     execute_queries,
     tokenize,
+    SynonymAnalyzer,
 )
 
 
@@ -24,6 +25,16 @@ def test_token_stemming():
     tokens = list(tokenize(content, stopwords))
 
     assert tokens[0] == ('onion',)
+
+
+def test_token_synonyms():
+    content = 'soymilk'
+    synonyms = {'soymilk': 'soy milk'}
+
+    analyzer = SynonymAnalyzer(synonyms=synonyms)
+    tokens = list(tokenize(content, analyzer=analyzer))
+
+    assert tokens == [('soy', 'milk'), ('soy',), ('milk',)]
 
 
 def test_stemming_consistency():

--- a/web/search.py
+++ b/web/search.py
@@ -15,11 +15,38 @@ class SnowballStemmer():
         return self.stemmer_en.stemWord(self.stemmer_en.stemWord(x))
 
 
-def tokenize(doc, stopwords=None, ngrams=None, stemmer=SnowballStemmer):
+class NullAnalyzer():
+
+    def process(self, input):
+        for token in input.split(' '):
+            for result in self.analyze_token(token):
+                yield result
+
+    def analyze_token(self, token):
+        yield token
+
+
+class SynonymAnalyzer(NullAnalyzer):
+
+    def __init__(self, synonyms):
+        self.synonyms = synonyms
+
+    def analyze_token(self, token):
+        token = self.synonyms.get(token) or token
+        for token in token.split(' '):
+            yield token
+
+
+def tokenize(doc, stopwords=None, ngrams=None, stemmer=SnowballStemmer,
+             analyzer=None):
     stopwords = stopwords or []
     stemmer = stemmer() if stemmer else None
+    analyzer = analyzer or NullAnalyzer()
 
-    word_count = len(doc.split(' '))
+    words = list(analyzer.process(doc))
+    word_count = len(words)
+    doc = ' '.join(words)
+
     ngrams = ngrams or word_count
     ngrams = min(ngrams, word_count, 4)
     ngrams = max(ngrams, 1)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Adds tokenization-level support for synonyms in the `knowledge-graph`, by adding an optional `analyzer` parameter to the `tokenize` method.

Initially a `SynonymAnalyzer` implementation is provided which uses a dictionary to map from input tokens to output tokens.

### How have the changes been tested?
1. Unit tests are provided with the change

**List any issues that this change relates to**
Relates to #21 