### PR TITLE
Add query-time analyzer support

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -46,7 +46,7 @@ def test_stemming_consistency():
     add_to_search_index(index, 0, content.content)
     hits = execute_queries(index, [content.name])
 
-    assert hits
+    assert next(hits)
 
 
 def test_analysis_consistency():
@@ -58,7 +58,7 @@ def test_analysis_consistency():
     add_to_search_index(index, 0, content.content, analyzer=analyzer)
     hits = execute_queries(index, ['soy milk'], analyzer=analyzer)
 
-    assert hits
+    assert next(hits)
 
 
 def test_exact_match():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -49,6 +49,18 @@ def test_stemming_consistency():
     assert hits
 
 
+def test_analysis_consistency():
+    content = Product(name='soymilk', frequency=1)
+    synonyms = {'soymilk': 'soy milk'}
+    analyzer = SynonymAnalyzer(synonyms=synonyms)
+
+    index = build_search_index()
+    add_to_search_index(index, 0, content.content, analyzer=analyzer)
+    hits = execute_queries(index, ['soy milk'], analyzer=analyzer)
+
+    assert hits
+
+
 def test_exact_match():
     content = 'whole onion'
     stopwords = ['whole']

--- a/web/search.py
+++ b/web/search.py
@@ -56,9 +56,9 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=SnowballStemmer,
             yield term
 
 
-def add_to_search_index(index, doc_id, doc, stopwords=None):
+def add_to_search_index(index, doc_id, doc, stopwords=None, analyzer=None):
     stopwords = stopwords or []
-    for term in tokenize(doc, stopwords):
+    for term in tokenize(doc, stopwords=stopwords, analyzer=analyzer):
         index.add_term_occurrence(term, doc_id)
 
 
@@ -76,17 +76,18 @@ def execute_exact_query(index, term):
             return doc_id
 
 
-def execute_queries(index, queries, stopwords=None, query_limit=1):
+def execute_queries(index, queries, stopwords=None, analyzer=None,
+                    query_limit=1):
     for query in queries:
-        hits = execute_query(index, query, stopwords, query_limit)
+        hits = execute_query(index, query, stopwords, analyzer, query_limit)
         if hits:
             yield query, hits
 
 
-def execute_query(index, query, stopwords=None, query_limit=1):
+def execute_query(index, query, stopwords=None, analyzer=None, query_limit=1):
     hits = defaultdict(lambda: 0)
     query_count = 0
-    for term in tokenize(query, stopwords):
+    for term in tokenize(query, stopwords=stopwords, analyzer=analyzer):
         query_count += 1
         try:
             for doc_id in index.get_documents(term):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
https://github.com/openculinary/knowledge-graph/pull/29 implemented indexing-time support for synonyms via a new `analyzer` parameter.

This changeset adds support for a configurable `analyzer` at query-time.

### How have the changes been tested?
1. Unit tests are provided

**List any issues that this change relates to**
Relates to #29 
