### PR TITLE
Canonicalization refactor

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,9 +9,11 @@ def test_ingredient_query(stopwords, hierarchy, client):
     stopwords.return_value = []
     hierarchy.return_value = [
         Product(name='onion', frequency=10, parent_id=None),
+        Product(name='soy milk', frequency=5, parent_id=None),
     ]
     expected_products = {
         'large onion, diced, ': 'onion',
+        'soymilk': 'soy milk',
     }
 
     results = client.post(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,6 @@
 import pytest
 
-from web.loader import canonicalize, discard
+from web.loader import discard
 
 
 def construct_product(product, recipe_count=10):
@@ -23,18 +23,3 @@ def test_discard(product, expected):
     result = discard(product)
 
     assert result is expected
-
-
-def canonicalization_cases():
-    return {
-        'cod filet': 'cod fillet',
-        'black beans (pre-soaked)': 'black beans',
-        'coriander': 'cilantro',
-    }.items()
-
-
-@pytest.mark.parametrize('name,expected', canonicalization_cases())
-def test_canonicalization(name, expected):
-    result = canonicalize(name)
-
-    assert result == expected

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -154,7 +154,7 @@ def test_product_categories(name, category):
 def canonicalization_cases():
     return {
         'cod filet': 'cod fillet',
-        'black beans': 'black beans',
+        'black beans': 'black bean',
         'coriander': 'cilantro',
     }.items()
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -72,18 +72,18 @@ def test_duplicate_consolidation():
     assert a1.id == a2.id == a3.id
 
 
-def test_stopword_token_filtering():
+def test_stopword_filtering():
     a1 = generate_product(name='chopped dried apricot')
     a1.stopwords = ['dri']
 
-    assert list(a1.tokens) == ['chop', 'apricot']
+    assert a1.to_doc() == 'chop apricot'
 
 
 def test_content_rendering():
     a1 = generate_product(name='chopped cooked chicken')
     a1.stopwords = ['chop', 'cook']
 
-    assert a1.content == 'chicken'
+    assert a1.to_doc() == 'chicken'
 
 
 def test_metadata():
@@ -163,4 +163,4 @@ def canonicalization_cases():
 def test_product_canonicalization(name, expected):
     product = Product(name=name)
 
-    assert product.content == expected
+    assert product.to_doc() == expected

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -26,6 +26,9 @@ def test_merge_products():
     assert a1.frequency == 12
     assert a1.name == 'liquid smoke'
 
+    assert a1.id == 'liquid_smoke'
+    assert a2.id == a1.id
+
 
 def test_calculate_depth():
     a1 = generate_product(name='a1')
@@ -73,7 +76,7 @@ def test_stopword_token_filtering():
     a1 = generate_product(name='chopped dried apricot')
     a1.stopwords = ['dri']
 
-    assert a1.tokens == ('chop', 'apricot')
+    assert list(a1.tokens) == ['chop', 'apricot']
 
 
 def test_content_rendering():

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -149,3 +149,18 @@ def test_product_categories(name, category):
     product = generate_product(name=name)
 
     assert product.category == category
+
+
+def canonicalization_cases():
+    return {
+        'cod filet': 'cod fillet',
+        'black beans': 'black beans',
+        'coriander': 'cilantro',
+    }.items()
+
+
+@pytest.mark.parametrize('name,expected', canonicalization_cases())
+def test_product_canonicalization(name, expected):
+    product = Product(name=name)
+
+    assert product.content == expected

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -40,22 +40,23 @@ def test_token_synonyms():
 def test_stemming_consistency():
     # some words change more than once under repeated snowball stemming
     # i.e. mayonnaise -> mayonnais -> mayonnai
-    content = Product(name='mayonnaise', frequency=1)
+    product = Product(name='mayonnaise', frequency=1)
+    doc = product.to_doc()
 
     index = build_search_index()
-    add_to_search_index(index, 0, content.content)
-    hits = execute_queries(index, [content.name])
+    add_to_search_index(index, 0, doc)
+    hits = execute_queries(index, [doc])
 
     assert next(hits)
 
 
 def test_analysis_consistency():
-    content = Product(name='soymilk', frequency=1)
+    product = Product(name='soymilk', frequency=1)
     synonyms = {'soymilk': 'soy milk'}
     analyzer = SynonymAnalyzer(synonyms=synonyms)
 
     index = build_search_index()
-    add_to_search_index(index, 0, content.content, analyzer=analyzer)
+    add_to_search_index(index, 0, product.to_doc(), analyzer=analyzer)
     hits = execute_queries(index, ['soy milk'], analyzer=analyzer)
 
     assert next(hits)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -10,29 +10,40 @@ from web.search import (
 
 
 def test_tokenize_stopwords():
-    content = 'red bell peppers diced'
+    doc = 'red bell peppers diced'
     stopwords = ['dice']
 
-    tokens = list(tokenize(content, stopwords))
+    tokens = list(tokenize(
+        doc=doc,
+        stopwords=stopwords,
+        stemmer=Product.stemmer
+    ))
 
     assert tokens[0] == ('red', 'bell', 'pepper')
 
 
 def test_token_stemming():
-    content = 'onions, finely chopped'
+    doc = 'onions, finely chopped'
     stopwords = ['fine', 'chop']
 
-    tokens = list(tokenize(content, stopwords))
+    tokens = list(tokenize(
+        doc=doc,
+        stopwords=stopwords,
+        stemmer=Product.stemmer
+    ))
 
     assert tokens[0] == ('onion',)
 
 
 def test_token_synonyms():
-    content = 'soymilk'
+    doc = 'soymilk'
     synonyms = {'soymilk': 'soy milk'}
 
     analyzer = SynonymAnalyzer(synonyms=synonyms)
-    tokens = list(tokenize(content, analyzer=analyzer))
+    tokens = list(tokenize(
+        doc=doc,
+        analyzer=analyzer
+    ))
 
     assert tokens == [('soy', 'milk'), ('soy',), ('milk',)]
 

--- a/web/app.py
+++ b/web/app.py
@@ -38,6 +38,7 @@ def find_product_candidates(products):
         index=app.graph.index,
         queries=queries,
         stopwords=app.stopwords,
+        stemmer=Product.stemmer,
         analyzer=Product.analyzer,
         query_limit=-1
     )
@@ -59,6 +60,7 @@ def query():
             index=description_index,
             doc_id=doc_id,
             doc=product.name,
+            stemmer=product.stemmer,
             analyzer=product.analyzer
         )
 
@@ -69,6 +71,7 @@ def query():
         hits = execute_query(
             index=description_index,
             query=candidate.name,
+            stemmer=candidate.stemmer,
             analyzer=candidate.analyzer
         )
         for hit in hits:

--- a/web/loader.py
+++ b/web/loader.py
@@ -16,15 +16,6 @@ CACHE_PATHS = {
 }
 
 
-canonicalizations = {}
-with open('web/data/canonicalizations.txt') as f:
-    for line in f.readlines():
-        if line.startswith('#'):
-            continue
-        source, target = line.strip().split(',')
-        canonicalizations[source] = target
-
-
 def discard(product):
     # Discard rare items
     if product['recipe_count'] < 5:
@@ -47,7 +38,7 @@ def discard(product):
     return False
 
 
-def canonicalize(name):
+def prefilter(name):
 
     # Remove text enclosed by parentheses
     open_parens = name.find('(')
@@ -97,7 +88,7 @@ def retrieve_products(filename):
             continue
 
         yield Product(
-            name=canonicalize(product['product']),
+            name=prefilter(product['product']),
             frequency=product['recipe_count']
         )
     print(f'- {count} products loaded')

--- a/web/loader.py
+++ b/web/loader.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 import requests
-import string
 
 from ingreedypy import Ingreedy
 

--- a/web/loader.py
+++ b/web/loader.py
@@ -46,12 +46,6 @@ def prefilter(name):
     if open_parens > 0 and close_parens > open_parens:
         name = name[:open_parens - 1] + name[close_parens + 1:]
 
-    # Remove punctuation in-between words
-    name = ' '.join([
-        word.strip(string.punctuation)
-        for word in name.split(' ')
-    ])
-
     # Attempt ingreedy-py parsing; drop quantity-related text on success
     try:
         parse = Ingreedy().parse(name)

--- a/web/loader.py
+++ b/web/loader.py
@@ -61,12 +61,6 @@ def canonicalize(name):
         for word in name.split(' ')
     ])
 
-    # Canonicalize each word
-    name = ' '.join([
-        canonicalizations.get(word) or word
-        for word in name.split(' ')
-    ])
-
     # Attempt ingreedy-py parsing; drop quantity-related text on success
     try:
         parse = Ingreedy().parse(name)

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -6,6 +6,19 @@ from web.search import tokenize, SynonymAnalyzer
 
 class Product(object):
 
+    class ProductAnalyzer(SynonymAnalyzer):
+
+        def __init__(self):
+            canonicalizations = {}
+            with open('web/data/canonicalizations.txt') as f:
+                for line in f.readlines():
+                    if line.startswith('#'):
+                        continue
+                    source, target = line.strip().split(',')
+                    canonicalizations[source] = target
+            super().__init__(canonicalizations)
+
+    analyzer = ProductAnalyzer()
     inflector = inflect.engine()
 
     def __init__(self, name, frequency=0, parent_id=None):
@@ -49,9 +62,7 @@ class Product(object):
 
     @property
     def tokens(self):
-        from web.loader import canonicalizations
-        analyzer = SynonymAnalyzer(canonicalizations)
-
+        analyzer = Product.ProductAnalyzer()
         for term in tokenize(self.name, self.stopwords, analyzer=analyzer):
             for subterm in term:
                 yield subterm

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -8,7 +8,7 @@ class Product(object):
 
     inflector = inflect.engine()
 
-    def __init__(self, name, frequency, parent_id=None):
+    def __init__(self, name, frequency=0, parent_id=None):
         self.name = self.canonicalize(name)
         self.frequency = frequency
         self.parent_id = parent_id

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -1,10 +1,24 @@
 import inflect
 import json
 
-from web.search import tokenize, SnowballStemmer, SynonymAnalyzer
+from snowballstemmer import stemmer
+
+from web.search import (
+    tokenize,
+    SynonymAnalyzer,
+)
 
 
 class Product(object):
+
+    class ProductStemmer:
+
+        stemmer_en = stemmer('english')
+
+        def stem(self, x):
+            # TODO: Remove double-stemming
+            # mayonnaise -> mayonnais -> mayonnai
+            return self.stemmer_en.stemWord(self.stemmer_en.stemWord(x))
 
     class ProductAnalyzer(SynonymAnalyzer):
 
@@ -18,6 +32,7 @@ class Product(object):
                     canonicalizations[source] = target
             super().__init__(canonicalizations)
 
+    stemmer = ProductStemmer()
     analyzer = ProductAnalyzer()
     inflector = inflect.engine()
 
@@ -60,7 +75,7 @@ class Product(object):
         for term in tokenize(
             doc=self.name,
             stopwords=self.stopwords if stopwords else [],
-            stemmer=SnowballStemmer if stemmer else None,
+            stemmer=self.stemmer if stemmer else None,
             analyzer=self.analyzer if analyzer else None
         ):
             for subterm in term:

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -49,8 +49,10 @@ class Product(object):
 
     @staticmethod
     def canonicalize(name, stopwords=None):
+        from web.loader import canonicalizations
         words = name.split(' ')
         words = [word for word in words if list(tokenize(word, stopwords))]
+        words = [canonicalizations.get(word) or word for word in words]
         return ' '.join(words)
 
     @property

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -57,12 +57,11 @@ class Product(object):
 
     @property
     def tokens(self):
-        terms = tuple()
         for term in tokenize(self.name, self.stopwords):
+            for subterm in term:
+                yield subterm
             if len(term) > 1:
-                return term
-            terms += term
-        return terms
+                return
 
     @property
     def content(self):

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -1,3 +1,4 @@
+from web.models.product import Product
 from web.search import (
     add_to_search_index,
     build_search_index,
@@ -45,7 +46,7 @@ class ProductGraph(object):
                 if line.startswith('#'):
                     continue
                 line = line.strip().lower()
-                for term in tokenize(line):
+                for term in tokenize(line, stemmer=Product.stemmer):
                     yield term[0]
 
     def calculate_stopwords(self):
@@ -61,7 +62,11 @@ class ProductGraph(object):
         clearwords = list(self.get_clearwords())
         stopwords = stopwords or self.calculate_stopwords()
         for stopword in stopwords:
-            for term in tokenize(stopword, clearwords):
+            for term in tokenize(
+                doc=stopword,
+                stopwords=clearwords,
+                stemmer=Product.stemmer
+            ):
                 if execute_exact_query(self.index, term):
                     continue
                 yield stopword
@@ -82,7 +87,11 @@ class ProductGraph(object):
 
     def filter_products(self):
         for product in self.products_by_id.values():
-            for term in tokenize(product.name, ngrams=1):
+            for term in tokenize(
+                doc=product.name,
+                ngrams=1,
+                stemmer=Product.stemmer
+            ):
                 doc_id = execute_exact_query(self.stopword_index, term)
                 if doc_id is not None:
                     product.stopwords.append(self.stopwords[doc_id])

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -161,7 +161,7 @@ class ProductGraph(object):
                 parent = self.products_by_id[parent_id]
                 if primary_parent is None:
                     primary_parent = parent
-                if len(parent.tokens) > len(primary_parent.tokens):
+                if len(list(parent.tokens)) > len(list(primary_parent.tokens)):
                     primary_parent = parent
 
             # Assign the parent

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -31,7 +31,7 @@ class ProductGraph(object):
             if count % 1000 == 0:
                 print(f'- {count} documents indexed')
 
-            add_to_search_index(index, product.id, product.content)
+            add_to_search_index(index, product.id, product.to_doc())
             if product.id not in self.products_by_id:
                 self.products_by_id[product.id] = product
             else:
@@ -93,7 +93,7 @@ class ProductGraph(object):
         return self.stopwords
 
     def find_children(self, product):
-        hits = execute_query(self.index, product.content)
+        hits = execute_query(self.index, product.to_doc())
         for hit in hits:
             doc_id = hit['doc_id']
             if doc_id != product.id:
@@ -161,7 +161,10 @@ class ProductGraph(object):
                 parent = self.products_by_id[parent_id]
                 if primary_parent is None:
                     primary_parent = parent
-                if len(list(parent.tokens)) > len(list(primary_parent.tokens)):
+
+                parent_tokens = list(parent.tokenize())
+                primary_tokens = list(primary_parent.tokenize())
+                if len(parent_tokens) > len(primary_tokens):
                     primary_parent = parent
 
             # Assign the parent


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
There had been a decent amount of tech debt building in between the web endpoint, product models, and core search code in the `knowledge-graph`.

Recent changes to canonicalization in order to support query-time evaluation of synonyms had highlighted this again, and it seems worthwhile to pay down some of the debt with this changeset.

### Briefly summarize the changes
1. Canonicalization logic is moved into the core `Product` class
1. Consistent `ProducyAnalyzer` and `ProductStemmer` subclasses are introduced for indexing and query-time document transformation
1. Product display name, content generation and ID generation are refactored

### How have the changes been tested?
1. Unit test coverage is provided
1. The product `hierarchy.json` has been regenerated locally via `pipenv run python -m scripts.hierarchy --update`

**List any issues that this change relates to**
Relates to #29 
Relates to #30 
