### PR TITLE
Improve markup term consumption

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -25,6 +25,7 @@ def test_ingredient_query(stopwords, hierarchy, client):
         'block tofu': 'tofu',
         'pressed soft tofu': 'soft tofu',
         'soymilk': 'soy milk',
+        'quart of soymilk in a cup': 'soy milk',
     }
 
     results = client.post(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,7 @@ def test_ingredient_query(stopwords, hierarchy, client):
         Product(name='firm tofu', frequency=10, parent_id='tofu'),
         Product(name='soft tofu', frequency=5, parent_id='tofu'),
         Product(name='soy milk', frequency=5, parent_id=None),
+        Product(name='red bell pepper', frequency=5, parent_id=None),
     ]
     expected_products = {
         'large onion, diced': 'onion',
@@ -26,6 +27,7 @@ def test_ingredient_query(stopwords, hierarchy, client):
         'pressed soft tofu': 'soft tofu',
         'soymilk': 'soy milk',
         'quart of soymilk in a cup': 'soy milk',
+        'sliced red bell pepper as filling': 'red bell pepper',
     }
 
     results = client.post(

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -45,7 +45,7 @@ def test_token_synonyms():
         analyzer=analyzer
     ))
 
-    assert tokens == [('soy', 'milk'), ('soy',), ('milk',)]
+    assert tokens == [('soy', 'milk'), ('soy',), ('milk',), ()]
 
 
 def test_stemming_consistency():

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -122,7 +122,7 @@ class Product(object):
         for term in terms:
 
             # Generate unstemmed ngrams of the same length as the product match
-            remaining_tokens = None
+            remaining_tokens = []
             n = len(term)
             tag = 0
             for tokens in tokenize(
@@ -131,16 +131,24 @@ class Product(object):
                 stemmer=None,
                 analyzer=self.analyzer
             ):
-                if len(tokens) < n:
-                    markup += ' ' if remaining_tokens else ''
-                    markup += ' '.join(remaining_tokens)
-                    tag = 1 if tag > 0 else 0
+                # If generated tokens are depleted, consume remaining tokens
+                if len(tokens) < n and len(remaining_tokens) > 0:
+                    tokens = remaining_tokens
 
+                # Continue token-by-token advancement, closing any open tags
                 tag -= 1
                 if tag == 0:
                     markup += '</mark>'
 
+                # If tokens are depleted and a tag is open, close after the tag
+                if len(tokens) < n and tag > 0:
+                    markup += f' {" ".join(tokens[:tag])}'
+                    markup += '</mark>'
+                    tokens = tokens[tag:]
+
+                # If tokens are depleted, write remaining tokens to the output
                 if len(tokens) < n:
+                    markup += f' {" ".join(tokens)}'
                     break
 
                 markup += ' '

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -110,12 +110,7 @@ class Product(object):
         self.depth = depth
         return depth
 
-    def get_metadata(self, description, graph, terms=None):
-        singular = Product.inflector.singular_noun(self.name)
-        singular = singular or self.name
-        plural = Product.inflector.plural_noun(singular)
-        is_plural = plural in description
-        terms = terms or []
+    def get_markup(self, description, terms):
 
         # Apply markup to the input description text
         markup = ''
@@ -172,8 +167,17 @@ class Product(object):
                 markup += f'{tokens[0]}'
                 remaining_tokens = tokens[1:]
 
+        return markup.strip()
+
+    def get_metadata(self, description, graph, terms=None):
+        singular = Product.inflector.singular_noun(self.name)
+        singular = singular or self.name
+        plural = Product.inflector.plural_noun(singular)
+        is_plural = plural in description
+        markup = self.get_markup(description, terms or [])
+
         return {
-            'markup': markup.strip() or None,
+            'markup': markup or None,
             'product': plural if is_plural else singular,
             'is_plural': is_plural,
             'singular': singular,

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -47,7 +47,7 @@ class ProductGraph(object):
                     continue
                 line = line.strip().lower()
                 for term in tokenize(line, stemmer=Product.stemmer):
-                    yield term[0]
+                    yield term[0:1]
 
     def calculate_stopwords(self):
         for term in self.index.terms():

--- a/web/search.py
+++ b/web/search.py
@@ -45,6 +45,7 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
     for ngrams in range(ngrams, 0, -1):
         for term in word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
             yield term
+    yield tuple()
 
 
 def add_to_search_index(index, doc_id, doc, stopwords=None, stemmer=None,
@@ -55,7 +56,8 @@ def add_to_search_index(index, doc_id, doc, stopwords=None, stemmer=None,
             stopwords=stopwords,
             stemmer=stemmer,
             analyzer=analyzer):
-        index.add_term_occurrence(term, doc_id)
+        if term:
+            index.add_term_occurrence(term, doc_id)
 
 
 def build_search_index():

--- a/web/search.py
+++ b/web/search.py
@@ -45,6 +45,8 @@ def tokenize(doc, stopwords=None, ngrams=None, stemmer=None, analyzer=None):
     for ngrams in range(ngrams, 0, -1):
         for term in word_tokenize(doc, stopwords, ngrams, stemmer=stemmer):
             yield term
+
+    # Produce an end-of-stream marker
     yield tuple()
 
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Markup generation for ingredients with ngrams > 1 was incorrect.

### Briefly summarize the changes
1. During token stream generation, output an empty tuple as an end-of-stream marker
1. During markup generation, track the number of expected tokens once a matching term is found
1. Emit an opening tag when a matching ingredient term is found
1. When the token stream is depleted or after sufficient tokens have been processed, closed the markup tag

### How have the changes been tested?
1. Unit tests are provided

**List any issues that this change relates to**
Fixes #32 