### PR TITLE
Separate product-related and query-related response fields

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,9 +40,9 @@ def test_ingredient_query(stopwords, hierarchy, client):
         basic_description = ' '.join(Product.analyzer.process(description))
         basic_description = basic_description.translate(remove_punctuation)
 
-        markup = results[description]['markup']
+        markup = results[description]['query']['markup']
         tagged_product = f'<mark>{product}</mark>'
 
-        assert results[description]['product'] == product
+        assert results[description]['product']['product'] == product
         assert tagged_product in markup
         assert markup.replace(tagged_product, product) == basic_description

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -110,74 +110,13 @@ class Product(object):
         self.depth = depth
         return depth
 
-    def get_markup(self, description, terms):
-
-        # Apply markup to the input description text
-        markup = ''
-        for term in terms:
-
-            # Generate unstemmed ngrams of the same length as the product match
-            remaining_tokens = []
-            n = len(term)
-            tag = 0
-            for tokens in tokenize(
-                doc=description,
-                ngrams=n,
-                stemmer=None,
-                analyzer=self.analyzer
-            ):
-                # If generated tokens are depleted, consume remaining tokens
-                if len(tokens) < n and len(remaining_tokens) > 0:
-                    tokens = remaining_tokens
-
-                # Continue token-by-token advancement, closing any open tags
-                tag -= 1
-                if tag == 0:
-                    markup += '</mark>'
-
-                # If tokens are depleted and a tag is open, close after the tag
-                if len(tokens) < n and tag > 0:
-                    markup += f' {" ".join(tokens[:tag])}'
-                    markup += '</mark>'
-                    tokens = tokens[tag:]
-
-                # If tokens are depleted, write remaining tokens to the output
-                if len(tokens) < n:
-                    markup += f' {" ".join(tokens)}'
-                    break
-
-                markup += ' '
-
-                # Stem the original text to allow match equality comparsion
-                text = ' '.join(tokens)
-                for stemmed_tokens in tokenize(
-                    doc=text,
-                    ngrams=n,
-                    stemmer=self.stemmer,
-                    analyzer=self.analyzer
-                ):
-                    break
-
-                # Open a tag marker when we find a matching term
-                if stemmed_tokens == term:
-                    markup += f'<mark>'
-                    tag = n
-
-                # Append the next consumed original token when we do not
-                markup += f'{tokens[0]}'
-                remaining_tokens = tokens[1:]
-
-        return markup.strip()
-
     def get_metadata(self, description, graph, terms=None):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name
         plural = Product.inflector.plural_noun(singular)
         is_plural = plural in description
-        markup = self.get_markup(description, terms or [])
 
         return {
-            'markup': markup or None,
             'product': plural if is_plural else singular,
             'is_plural': is_plural,
             'singular': singular,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Resolves #34 

### Briefly summarize the changes
1. Place product metadata underneath a `product` response key, per-input-query
1. Place query metadata underneath a `query` response key, per-input-query

### How have the changes been tested?
1. Unit tests are updated

**List any issues that this change relates to**
Fixes #34 
