### PR TITLE
Add entity ID to response metadata

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -53,6 +53,7 @@ def test_ingredient_query(stopwords, hierarchy, client):
         markup = results[description]['query']['markup']
         tagged_product = f'<mark id="{product_id}">{product}</mark>'
 
+        assert results[description]['product']['id'] == product_id
         assert results[description]['product']['product'] == product
         assert tagged_product in markup
         assert markup.replace(tagged_product, product) == basic_description

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -117,6 +117,7 @@ class Product(object):
         is_plural = plural in description
 
         return {
+            'id': self.id,
             'product': plural if is_plural else singular,
             'is_plural': is_plural,
             'singular': singular,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Adds an entity ID value to the `knowledge-graph` query response.

This enables callers to look up entity details referenced in the `markup` response field.

### How have the changes been tested?
1. Unit test coverage is provided