### PR TITLE
Query processing: retain original query text formatting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ git = "https://github.com/jayaddison/hashedindex.git"
 ref = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267"
 
 [packages.hashedixsearch]
-file = "https://github.com/openculinary/hashedixsearch/raw/8bedd292a08c2a2af2dbc467bd68ece60be7d4cc/dist/hashedixsearch-0.1.2rc3-py3-none-any.whl"
+file = "https://github.com/openculinary/hashedixsearch/raw/6068f9173f0f9910994c47a5c98b565dd275d51e/dist/hashedixsearch-0.2.0rc0-py3-none-any.whl"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ python_version = "3.7"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.1.0"
 inflect = "==4.1.0"
 ingreedypy = "==1.3.1"
 requests = "==2.22.0"
@@ -18,3 +17,10 @@ snowballstemmer = "==2.0.0"
 [dev-packages]
 flake8 = "*"
 pytest = "*"
+
+[packages.hashedindex]
+git = "https://github.com/jayaddison/hashedindex.git"
+ref = "3a7e46a22c04960a0a50a2fca2d25cee7b4f9267"
+
+[packages.hashedixsearch]
+file = "https://github.com/openculinary/hashedixsearch/raw/8bedd292a08c2a2af2dbc467bd68ece60be7d4cc/dist/hashedixsearch-0.1.2rc3-py3-none-any.whl"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -49,13 +49,13 @@ def test_ingredient_query(stopwords, hierarchy, client):
             'product': 'soy milk',
             'product_id': 'milk_soy',
         },
-        'quart of soymilk in a cup': {
-            'markup': 'quart of <mark>soy milk</mark> in a cup',
+        '250ml of soymilk (roughly one cup)': {
+            'markup': '250ml of <mark>soy milk</mark> (roughly one cup)',
             'product': 'soy milk',
             'product_id': 'milk_soy',
         },
-        'sliced red bell pepper as filling': {
-            'markup': 'sliced <mark>red bell pepper</mark> as filling',
+        'Sliced red bell pepper, as filling': {
+            'markup': 'Sliced <mark>red bell pepper</mark>, as filling',
             'product': 'red bell pepper',
             'product_id': 'bell_pepper_red',
         },

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,5 @@
 from unittest.mock import patch
 
-from string import punctuation
-
 from web.models.product import Product
 
 
@@ -19,41 +17,56 @@ def test_ingredient_query(stopwords, hierarchy, client):
         Product(name='soy milk', frequency=5, parent_id=None),
         Product(name='red bell pepper', frequency=5, parent_id=None),
     ]
-    expected_products = {
-        'large onion, diced': 'onion',
-        'can of baked beans': 'bake_bean',
-        'block of firm tofu': 'firm_tofu',
-        'block tofu': 'tofu',
-        'pressed soft tofu': 'soft_tofu',
-        'soymilk': 'milk_soy',
-        'quart of soymilk in a cup': 'milk_soy',
-        'sliced red bell pepper as filling': 'bell_pepper_red',
-    }
-    products = {
-        'onion': 'onion',
-        'bake_bean': 'baked beans',
-        'firm_tofu': 'firm tofu',
-        'tofu': 'tofu',
-        'soft_tofu': 'soft tofu',
-        'milk_soy': 'soy milk',
-        'bell_pepper_red': 'red bell pepper',
+
+    expected_results = {
+        'large onion, diced': {
+            'markup': 'large <mark>onion</mark>, diced',
+            'product': 'onion',
+            'product_id': 'onion',
+        },
+        'can of baked beans': {
+            'markup': 'can of <mark>baked beans</mark>',
+            'product': 'baked beans',
+            'product_id': 'bake_bean',
+        },
+        'block of firm tofu': {
+            'markup': 'block of <mark>firm tofu</mark>',
+            'product': 'firm tofu',
+            'product_id': 'firm_tofu',
+        },
+        'block tofu': {
+            'markup': 'block <mark>tofu</mark>',
+            'product': 'tofu',
+            'product_id': 'tofu',
+        },
+        'pressed soft tofu': {
+            'markup': 'pressed <mark>soft tofu</mark>',
+            'product': 'soft tofu',
+            'product_id': 'soft_tofu',
+        },
+        'soymilk': {
+            'markup': '<mark>soy milk</mark>',
+            'product': 'soy milk',
+            'product_id': 'milk_soy',
+        },
+        'quart of soymilk in a cup': {
+            'markup': 'quart of <mark>soy milk</mark> in a cup',
+            'product': 'soy milk',
+            'product_id': 'milk_soy',
+        },
+        'sliced red bell pepper as filling': {
+            'markup': 'sliced <mark>red bell pepper</mark> as filling',
+            'product': 'red bell pepper',
+            'product_id': 'bell_pepper_red',
+        },
     }
 
     results = client.post(
         '/ingredients/query',
-        data={'descriptions[]': list(expected_products.keys())}
+        data={'descriptions[]': list(expected_results.keys())}
     ).json['results']
 
-    remove_punctuation = str.maketrans('', '', punctuation)
-    for description, product_id in expected_products.items():
-        basic_description = ' '.join(Product.analyzer.process(description))
-        basic_description = basic_description.translate(remove_punctuation)
-
-        product = products[product_id]
-        markup = results[description]['query']['markup']
-        tagged_product = f'<mark>{product}</mark>'
-
-        assert results[description]['product']['id'] == product_id
-        assert results[description]['product']['product'] == product
-        assert tagged_product in markup
-        assert markup.replace(tagged_product, product) == basic_description
+    for query, expected in expected_results.items():
+        assert results[query]['product']['id'] == expected['product_id']
+        assert results[query]['product']['product'] == expected['product']
+        assert results[query]['query']['markup'] == expected['markup']

--- a/web/app.py
+++ b/web/app.py
@@ -40,7 +40,7 @@ def find_product_candidates(products):
         queries=queries,
         stopwords=app.stopwords,
         stemmer=Product.stemmer,
-        synonyms=Product.ProductAnalyzer().synonyms,
+        synonyms=Product.canonicalizations,
         query_limit=-1
     )
     for description, hits in results:
@@ -62,7 +62,7 @@ def query():
             doc_id=doc_id,
             doc=product.name,
             stemmer=product.stemmer,
-            synonyms=Product.ProductAnalyzer().synonyms,
+            synonyms=Product.canonicalizations,
         )
 
     # Track the best match for each product
@@ -73,7 +73,7 @@ def query():
             index=description_index,
             query=candidate.name,
             stemmer=candidate.stemmer,
-            synonyms=Product.ProductAnalyzer().synonyms,
+            synonyms=Product.canonicalizations,
         )
         for hit in hits:
             doc_id, score, terms = hit['doc_id'], hit['score'], hit['terms']
@@ -90,7 +90,7 @@ def query():
             query=description,
             terms=terms,
             stemmer=product.stemmer,
-            synonyms=Product.ProductAnalyzer().synonyms,
+            synonyms=Product.canonicalizations,
         )
         metadata[doc_id] = product.get_metadata(description, app.graph, terms)
 

--- a/web/app.py
+++ b/web/app.py
@@ -40,7 +40,7 @@ def find_product_candidates(products):
         queries=queries,
         stopwords=app.stopwords,
         stemmer=Product.stemmer,
-        analyzer=Product.analyzer,
+        synonyms=Product.ProductAnalyzer().synonyms,
         query_limit=-1
     )
     for description, hits in results:
@@ -62,7 +62,7 @@ def query():
             doc_id=doc_id,
             doc=product.name,
             stemmer=product.stemmer,
-            analyzer=product.analyzer
+            synonyms=Product.ProductAnalyzer().synonyms,
         )
 
     # Track the best match for each product
@@ -73,7 +73,7 @@ def query():
             index=description_index,
             query=candidate.name,
             stemmer=candidate.stemmer,
-            analyzer=candidate.analyzer
+            synonyms=Product.ProductAnalyzer().synonyms,
         )
         for hit in hits:
             doc_id, score, terms = hit['doc_id'], hit['score'], hit['terms']
@@ -90,7 +90,7 @@ def query():
             query=description,
             terms=terms,
             stemmer=product.stemmer,
-            analyzer=product.analyzer
+            synonyms=Product.ProductAnalyzer().synonyms,
         )
         metadata[doc_id] = product.get_metadata(description, app.graph, terms)
 

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -33,7 +33,6 @@ class Product(object):
             super().__init__(canonicalizations)
 
     stemmer = ProductStemmer()
-    analyzer = ProductAnalyzer()
     inflector = inflect.engine()
 
     def __init__(self, name, frequency=0, parent_id=None):
@@ -72,11 +71,14 @@ class Product(object):
         return data
 
     def tokenize(self, stopwords=True, stemmer=True, analyzer=True):
+        doc = self.name
+        if analyzer:
+            doc = str().join(self.ProductAnalyzer().process(doc))
+
         for term in tokenize(
-            doc=self.name,
+            doc=doc,
             stopwords=self.stopwords if stopwords else [],
             stemmer=self.stemmer if stemmer else None,
-            analyzer=self.analyzer if analyzer else None
         ):
             for subterm in term:
                 yield subterm


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Often the contextual description of ingredients may contain useful information that will be useful for users to refer to.  While adding markup to the results we should also retain the original text formatting where possible.

### Briefly summarize the changes
1. Update to a version of `hashedixsearch` that supports highlighting with retained text formatting

### How have the changes been tested?
1. Some test coverage has been updated to check the formatting functionality
1. Existing test coverage continues to pass
