### PR TITLE
Perform case-insensitive highlighting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.1"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.2.0"
+hashedixsearch = "==0.2.2"
 inflect = "==4.1.0"
 ingreedypy = "==1.3.1"
 requests = "==2.22.0"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,8 +24,8 @@ def test_ingredient_query(stopwords, hierarchy, client):
             'product': 'onion',
             'product_id': 'onion',
         },
-        'can of baked beans': {
-            'markup': 'can of <mark>baked beans</mark>',
+        'can of Baked Beans': {
+            'markup': 'can of <mark>Baked Beans</mark>',
             'product': 'baked beans',
             'product_id': 'bake_bean',
         },

--- a/web/app.py
+++ b/web/app.py
@@ -91,6 +91,7 @@ def query():
             terms=terms,
             stemmer=product.stemmer,
             synonyms=Product.canonicalizations,
+            case_sensitive=False,
         )
         metadata[doc_id] = product.get_metadata(description, app.graph, terms)
 

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -111,7 +111,7 @@ class Product(object):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name
         plural = Product.inflector.plural_noun(singular)
-        is_plural = plural in description
+        is_plural = plural in description.lower()
 
         return {
             'id': self.id,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Currently product names are stored lowercase, but are intended to match regardless of description text case.

### Briefly summarize the changes
1. Enable case-insensitive highlight matching via `hashedixsearch`

### How have the changes been tested?
1. Test coverage is provided