### PR TITLE
Migrate equipment queries from direction-parser service

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ hashedixsearch = "==0.2.5"
 inflect = "==4.1.0"
 ingreedypy = "==1.3.1"
 requests = "==2.22.0"
+stop-words = "==2018.7.23"
 snowballstemmer = "==2.0.0"
 
 [dev-packages]

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -1,0 +1,30 @@
+def test_description_parsing(client):
+    description_equipment = {
+        'Pre-heat the oven to 250 degrees F.': {
+            'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
+            'appliances': [{'appliance': 'oven'}],
+        },
+        'leave the Slow cooker on a low heat': {
+            'markup': 'leave the <mark>Slow cooker</mark> on a low heat',
+            'appliances': [{'appliance': 'slow cooker'}],
+        },
+        'place casserole dish in oven': {
+            'markup': 'place <mark>casserole dish</mark> in <mark>oven</mark>',
+            'appliances': [{'appliance': 'oven'}],
+            'vessels': [{'vessel': 'casserole dish'}],
+        },
+        'empty skewer into the karahi': {
+            'markup': 'empty <mark>skewer</mark> into the <mark>karahi</mark>',
+            'utensils': [{'utensil': 'skewer'}],
+            'vessels': [{'vessel': 'karahi'}],
+        },
+    }
+
+    response = client.post(
+        '/equipment/query',
+        data={'descriptions[]': list(description_equipment.keys())}
+    )
+    for result in response.json:
+        assert result['description'] in description_equipment
+        for key, value in description_equipment[result['description']].items():
+            assert result[key] == value

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -1,11 +1,15 @@
 from unittest.mock import patch
 
+from web.app import app
 from web.models.product import Product
 
 
-@patch('web.app.retrieve_hierarchy')
-@patch('web.app.retrieve_stopwords')
+@patch('web.ingredients.retrieve_hierarchy')
+@patch('web.ingredients.retrieve_stopwords')
 def test_ingredient_query(stopwords, hierarchy, client):
+    # HACK: Ensure that app initialization methods (re)run during this test
+    app._got_first_request = False
+
     stopwords.return_value = []
     hierarchy.return_value = [
         Product(name='onion', frequency=10, parent_id=None),

--- a/web/app.py
+++ b/web/app.py
@@ -1,26 +1,7 @@
 from flask import Flask
 
-from web.loader import (
-    CACHE_PATHS,
-    retrieve_hierarchy,
-    retrieve_stopwords,
-)
-from web.models.product_graph import ProductGraph
-
 app = Flask(__name__)
 
 
-@app.before_first_request
-def preload_graph():
-    filename = CACHE_PATHS['hierarchy']
-    hierarchy = retrieve_hierarchy(filename)
-
-    filename = CACHE_PATHS['stopwords']
-    stopwords = retrieve_stopwords(filename)
-
-    app.graph = ProductGraph(hierarchy, stopwords)
-    app.products = app.graph.filter_products()
-    app.stopwords = app.graph.filter_stopwords()
-
-
+import web.equipment
 import web.ingredients

--- a/web/data/equipment/appliances.txt
+++ b/web/data/equipment/appliances.txt
@@ -1,0 +1,109 @@
+Air fryer
+Assistent
+Bachelor griller
+Barbecue grill
+Batan
+Beehive oven
+Blade grinder
+Blender
+Brasero
+Brazier
+Bread machine
+Burjiko
+Burr mill
+Butane torch
+Can opener
+Cheesemelter
+Chocolatera
+Chorkor oven
+Clome oven
+Comal
+Combi steamer
+Communal oven
+Convection microwave
+Convection oven
+Corn roaster
+Crepe maker
+Deep fryer
+Dehydrator
+Earth oven
+Electric cooker
+Electric knife
+Energy regulator
+Espresso machine
+Field kitchen
+Fire pot
+Flattop grill
+Food processor
+Food steamer
+Fufu Machine
+Halogen oven
+Hand mixer
+Haybox
+Horno
+Hot box
+Hot plate
+Ice cream maker
+Immersion blender
+Instant Pot
+Kamado
+Kenwood Chef
+Kettle
+Kitchener range
+Kujiejun
+Kyoto box
+Lemon squeezer
+Magic Bullet
+Makiyakinabe
+Masonry oven
+Meat grinder
+Meat slicer
+Mess kit
+Microwave oven
+Multicooker
+Nutcracker
+Oven
+Pacojet
+Pancake machine
+Panini grill
+Panini press
+Peeler
+Popcorn maker
+Poppy seed grinder
+Pressure cooker
+Pressure fryer
+Reflector oven
+Remoska
+Rice cooker
+Rice polisher
+Rice pounder
+Roasting jack
+Rotimatic
+Rotisserie
+Russian oven
+Sabbath mode
+Salad spinner
+Salamander broiler
+Samovar
+Sandwich toaster
+Self-cleaning oven
+Shichirin
+Slow cooker
+Solar cooker
+Sous-vide cooker
+Spiral vegetable slicer
+Stand mixer
+Starch mogul
+Stove
+Susceptor
+Tabun oven
+Tandoor
+Tangia
+Toaster
+Turkey fryer
+Vacuum filler
+Vacuum fryer
+Veg-O-Matic
+Waffle iron
+Wet grinder
+Wood-fired oven

--- a/web/data/equipment/utensils.txt
+++ b/web/data/equipment/utensils.txt
@@ -1,0 +1,101 @@
+Aluminium foil
+Apple corer
+Baking stone
+Bamboo steamer
+Bedrock mortar
+Bottle opener
+Bottle scraper
+Butcher block
+Butcher paper
+Butter churn
+Butter curler
+Candy thermometer
+Chawan
+Cheesecloth
+Cherry pitter
+Chinois
+Chopsticks
+Church key
+Chushkopek
+Citrus reamer
+Cocktail stick
+Coffee filter
+Colander
+Cookie cutter
+Cookie press
+Corkscrew
+Crab cracker
+Cutlery
+Cutting board
+Dough scraper
+Egg slicer
+Fish slice
+Flesh-hook
+Food mill
+Potato ricer
+Frosting spatula
+Funnel
+Garlic peeler
+Garlic press
+Grater
+Greaseproof paper
+Heat diffuser
+Herb chopper
+Honey dipper
+Juicer
+Juicero
+Lemon squeezer
+Mallet
+Mandoline
+Masala dabba
+Measuring cup
+Measuring spoon
+Meat tenderizer
+Meat thermometer
+Melon ball
+Microplane
+Milk frother
+Milk watcher
+Mixer
+Mixing paddle
+Mouli grater
+Nutmeg grater
+Oven bag
+Parchment paper
+Pastry bag
+Pastry blender
+Pea sheller
+Peeler
+Plastic wrap
+Potato masher
+Pothook
+Pudding basin
+Pudding cloth
+Rice cooker
+Ricing
+Roasting jack
+Roller docker
+Saran
+Scraper
+Siru
+Skewer
+Skimmer
+Soup spoon
+Spatula
+Spiralizer
+Springform pan
+Spurtle
+Steam juicer
+Sugar nips
+Sujeo
+Tamis
+Timbale
+Tomato knife
+Tomato slicer
+Tongs
+Trivet
+Trussing needle
+Wax paper
+Whisk
+Wok brush
+Zester

--- a/web/data/equipment/vessels.txt
+++ b/web/data/equipment/vessels.txt
@@ -1,0 +1,53 @@
+Bain-marie
+Beanpot
+Billycan
+Bratt pan
+Bread pan
+Caquelon
+Casserole dish
+Cassole
+Cassolette
+Cast-iron cookware
+Cataplana
+Cauldron
+Chafing dish
+Chip pan
+Crepulja
+Crock
+Dolsot
+Double boiler
+Dutch oven
+Fish kettle
+French tian
+Frying pan
+Tava
+Gamasot
+Handi
+Karahi
+Kazan
+Marmite
+Mold
+Muffin tin
+Olla
+Pipkin
+Palayok
+Porringer
+Potjie
+Pressure cooker
+Ramekin
+Rice cooker
+Roasting pan
+Sinseollo
+Siru
+Slow cooker
+Springform pan
+Stock pot
+Sufuria
+Tagine
+Tajine
+Tangia
+Tapayan
+Terrine
+Ttukbaegi
+Uruli
+Wok

--- a/web/equipment.py
+++ b/web/equipment.py
@@ -1,0 +1,107 @@
+from collections import defaultdict
+from flask import jsonify, request
+from hashedixsearch import (
+   build_search_index,
+   execute_queries,
+   highlight,
+   tokenize,
+   NullStemmer,
+)
+from snowballstemmer import stemmer
+from stop_words import get_stop_words as get_stopwords
+
+from web.app import app
+from web.loader import (
+    CACHE_PATHS,
+    load_queries,
+)
+
+
+class EquipmentStemmer(NullStemmer):
+
+    stemmer_en = stemmer('english')
+
+    def stem(self, x):
+        return self.stemmer_en.stemWord(x)
+
+
+stopwords = get_stopwords('en')
+
+
+@app.before_first_request
+def preload_equipment_data():
+    app.appliance_queries = load_queries(CACHE_PATHS['appliance_queries'])
+    app.utensil_queries = load_queries(CACHE_PATHS['utensil_queries'])
+    app.vessel_queries = load_queries(CACHE_PATHS['vessel_queries'])
+
+
+def equipment_by_document(index, queries):
+    results_by_document = defaultdict(lambda: set())
+    stemmer = EquipmentStemmer()
+    equipment_hits = execute_queries(
+        index=index,
+        queries=queries,
+        stemmer=stemmer,
+        stopwords=stopwords
+    )
+    for equipment, hits in equipment_hits:
+        for hit in hits:
+            results_by_document[hit['doc_id']].add(equipment)
+    return results_by_document
+
+
+@app.route('/equipment/query', methods=['POST'])
+def equipment():
+    descriptions = request.form.getlist('descriptions[]')
+
+    stemmer = EquipmentStemmer()
+    index = build_search_index()
+    for doc_id, doc in enumerate(descriptions):
+        for ngrams in [1, 2]:
+            for term in tokenize(doc,
+                                 stopwords=stopwords,
+                                 ngrams=ngrams,
+                                 stemmer=stemmer):
+                index.add_term_occurrence(term, doc_id)
+
+    appliances_by_doc = equipment_by_document(index, app.appliance_queries)
+    utensils_by_doc = equipment_by_document(index, app.utensil_queries)
+    vessels_by_doc = equipment_by_document(index, app.vessel_queries)
+
+    markup_by_doc = {}
+    for doc_id, description in enumerate(descriptions):
+        equipment = (
+            appliances_by_doc[doc_id]
+            | utensils_by_doc[doc_id]
+            | vessels_by_doc[doc_id]
+        )
+        terms = []
+        for equipment in equipment:
+            terms.append(next(tokenize(equipment, stemmer=stemmer)))
+        markup_by_doc[doc_id] = highlight(
+            query=description,
+            terms=terms,
+            stemmer=stemmer,
+            case_sensitive=False
+        )
+
+    results = []
+    for doc_id, description in enumerate(descriptions):
+        results.append({
+            'index': doc_id,
+            'description': description,
+            'markup': markup_by_doc.get(doc_id),
+            'appliances': [
+                {'appliance': appliance}
+                for appliance in appliances_by_doc[doc_id]
+            ],
+            'utensils': [
+                {'utensil': utensil}
+                for utensil in utensils_by_doc[doc_id]
+            ],
+            'vessels': [
+                {'vessel': vessel}
+                for vessel in vessels_by_doc[doc_id]
+            ],
+        })
+    return jsonify(results)

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -9,7 +9,26 @@ from hashedixsearch import (
 )
 
 from web.app import app
+from web.loader import (
+    CACHE_PATHS,
+    retrieve_hierarchy,
+    retrieve_stopwords,
+)
 from web.models.product import Product
+from web.models.product_graph import ProductGraph
+
+
+@app.before_first_request
+def preload_ingredient_data():
+    filename = CACHE_PATHS['hierarchy']
+    hierarchy = retrieve_hierarchy(filename)
+
+    filename = CACHE_PATHS['stopwords']
+    stopwords = retrieve_stopwords(filename)
+
+    app.graph = ProductGraph(hierarchy, stopwords)
+    app.products = app.graph.filter_products()
+    app.stopwords = app.graph.filter_stopwords()
 
 
 def find_product_candidates(products):

--- a/web/loader.py
+++ b/web/loader.py
@@ -12,7 +12,15 @@ CACHE_PATHS = {
     'hierarchy': 'web/data/generated/hierarchy.json',
     'products': 'web/data/generated/ingredients.json',
     'stopwords': 'web/data/generated/stopwords.txt',
+    'appliance_queries': 'web/data/equipment/appliances.txt',
+    'utensil_queries': 'web/data/equipment/utensils.txt',
+    'vessel_queries': 'web/data/equipment/vessels.txt',
 }
+
+
+def load_queries(filename):
+    with open(filename) as f:
+        return [line.strip().lower() for line in f.readlines()]
 
 
 def discard(product):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The knowledge graph will increasingly have a need to reason about and cross-reference between different types of entity as the RecipeRadar application develops.

This changeset integrates the modeling and extraction of `equipment` entity data from the `direction-parser` service into the graph.