### PR TITLE
Handle unicode characters during ingredient name highlighting

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ ingreedypy = "==1.3.1"
 requests = "==2.22.0"
 stop-words = "==2018.7.23"
 snowballstemmer = "==2.0.0"
+unidecode = "==1.1.1"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.2"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.2.5"
+hashedixsearch = "==0.2.6"
 inflect = "==4.1.0"
 ingreedypy = "==1.3.1"
 requests = "==2.22.0"

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -17,8 +17,10 @@ def test_ingredient_query(stopwords, hierarchy, client):
         Product(name='bean', frequency=20, parent_id=None),
         Product(name='tofu', frequency=20, parent_id=None),
         Product(name='firm tofu', frequency=10, parent_id='tofu'),
+        Product(name='jalapeño', frequency=5),
         Product(name='soft tofu', frequency=5, parent_id='tofu'),
         Product(name='soy milk', frequency=5, parent_id=None),
+        Product(name='red bell pepper', frequency=5, parent_id=None),
         Product(name='red bell pepper', frequency=5, parent_id=None),
     ]
 
@@ -62,6 +64,11 @@ def test_ingredient_query(stopwords, hierarchy, client):
             'markup': 'Sliced <mark>red bell pepper</mark>, as filling',
             'product': 'red bell pepper',
             'product_id': 'bell_pepper_red',
+        },
+        'jalapeño pepper': {
+            'markup': '<mark>jalapeño</mark> pepper',
+            'product': 'jalapeño',
+            'product_id': 'jalapeno',
         },
     }
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -164,3 +164,9 @@ def test_product_canonicalization(name, expected):
     product = Product(name=name)
 
     assert product.to_doc() == expected
+
+
+def test_product_id_transliteration():
+    product = Product(name='jalapeño pepper')
+
+    assert product.id == 'jalapeno_pepper'

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -6,6 +6,7 @@ import inflect
 import json
 
 from snowballstemmer import stemmer
+from unidecode import unidecode
 
 
 class Product(object):
@@ -15,6 +16,7 @@ class Product(object):
         stemmer_en = stemmer('english')
 
         def stem(self, x):
+            x = unidecode(x)
             # TODO: Remove double-stemming
             # mayonnaise -> mayonnais -> mayonnai
             return self.stemmer_en.stemWord(self.stemmer_en.stemWord(x))


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset introduces support for markup highlighting of ingredient names that contain non-ASCII characters.  This has surfaced as an issue in openculinary/frontend#162.

### Briefly summarize the changes
1. Upgrade to a version of `hashedixsearch` that [supports](https://github.com/openculinary/hashedixsearch/pull/23) highlighting of non-ASCII terms
1. Perform transliteration during stemming of ingredient terms so that an ASCII version of each ingredient name and query is used to term matching purposes (i.e. allow `jalapeno` to match against `jalapeño`)

### How have the changes been tested?
1. The underlying `hashedixsearch` library's unit test coverage [demonstates](https://github.com/openculinary/hashedixsearch/blob/a59bb60b1a42f6ccc78217b8b7af07ee7c2462b2/tests/test_search.py#L231-L239) that this is possible
1. Unit test coverage is provided
1. Local development testing has been performed

**List any issues that this change relates to**
Relates to openculinary/hashedixsearch#23
Resolves openculinary/frontend#162