### PR TITLE
Remove /api prefix from 'api' service requests

### DIFF
--- a/web/loader.py
+++ b/web/loader.py
@@ -69,7 +69,7 @@ def retrieve_products(filename):
     else:
         print('Streaming product data from api')
         reader = requests.get(
-            url='http://localhost/api/products',
+            url='http://localhost/products',
             stream=True,
             proxies={}
         ).iter_lines


### PR DESCRIPTION
### Briefly summarize the changes
1. Remove the `/api` prefix from `api` service request paths

### How have the changes been tested?
1. Unit test coverage exercises the updated paths

**List any issues that this change relates to**
Relates to openculinary/infrastructure#23