### PR TITLE
Equipment metadata: render equipment class information as part of API response markup

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.8"
 [packages]
 flask = "==1.1.2"
 gunicorn = "==20.0.4"
-hashedixsearch = "==0.2.6"
+hashedixsearch = "==0.2.7"
 inflect = "==4.1.0"
 ingreedypy = "==1.3.1"
 requests = "==2.24.0"

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -1,20 +1,32 @@
 def test_description_parsing(client):
     description_equipment = {
         'Pre-heat the oven to 250 degrees F.': {
-            'markup': 'Pre-heat the <mark class="appliance">oven</mark> to 250 degrees F.',
+            'markup': (
+                'Pre-heat the <mark class="appliance">oven</mark> '
+                'to 250 degrees F.'
+            ),
             'appliances': [{'appliance': 'oven'}],
         },
         'leave the Slow cooker on a low heat': {
-            'markup': 'leave the <mark class="vessel">Slow cooker</mark> on a low heat',
+            'markup': (
+                'leave the <mark class="vessel">Slow cooker</mark> '
+                'on a low heat'
+            ),
             'appliances': [{'appliance': 'slow cooker'}],
         },
         'place casserole dish in oven': {
-            'markup': 'place <mark class="vessel">casserole dish</mark> in <mark class="appliance">oven</mark>',
+            'markup': (
+                'place <mark class="vessel">casserole dish</mark> '
+                'in <mark class="appliance">oven</mark>'
+            ),
             'appliances': [{'appliance': 'oven'}],
             'vessels': [{'vessel': 'casserole dish'}],
         },
         'empty skewer into the karahi': {
-            'markup': 'empty <mark class="utensil">skewer</mark> into the <mark class="vessel">karahi</mark>',
+            'markup': (
+                'empty <mark class="utensil">skewer</mark> into the '
+                '<mark class="vessel">karahi</mark>'
+            ),
             'utensils': [{'utensil': 'skewer'}],
             'vessels': [{'vessel': 'karahi'}],
         },

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -9,7 +9,7 @@ def test_description_parsing(client):
         },
         'leave the Slow cooker on a low heat': {
             'markup': (
-                'leave the <mark class="vessel">Slow cooker</mark> '
+                'leave the <mark class="appliance">Slow cooker</mark> '
                 'on a low heat'
             ),
             'appliances': [{'appliance': 'slow cooker'}],

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -1,20 +1,20 @@
 def test_description_parsing(client):
     description_equipment = {
         'Pre-heat the oven to 250 degrees F.': {
-            'markup': 'Pre-heat the <mark>oven</mark> to 250 degrees F.',
+            'markup': 'Pre-heat the <mark class="appliance">oven</mark> to 250 degrees F.',
             'appliances': [{'appliance': 'oven'}],
         },
         'leave the Slow cooker on a low heat': {
-            'markup': 'leave the <mark>Slow cooker</mark> on a low heat',
+            'markup': 'leave the <mark class="vessel">Slow cooker</mark> on a low heat',
             'appliances': [{'appliance': 'slow cooker'}],
         },
         'place casserole dish in oven': {
-            'markup': 'place <mark>casserole dish</mark> in <mark>oven</mark>',
+            'markup': 'place <mark class="vessel">casserole dish</mark> in <mark class="appliance">oven</mark>',
             'appliances': [{'appliance': 'oven'}],
             'vessels': [{'vessel': 'casserole dish'}],
         },
         'empty skewer into the karahi': {
-            'markup': 'empty <mark>skewer</mark> into the <mark>karahi</mark>',
+            'markup': 'empty <mark class="utensil">skewer</mark> into the <mark class="vessel">karahi</mark>',
             'utensils': [{'utensil': 'skewer'}],
             'vessels': [{'vessel': 'karahi'}],
         },

--- a/web/equipment.py
+++ b/web/equipment.py
@@ -70,19 +70,24 @@ def equipment():
 
     markup_by_doc = {}
     for doc_id, description in enumerate(descriptions):
-        equipment = (
-            appliances_by_doc[doc_id]
-            | utensils_by_doc[doc_id]
-            | vessels_by_doc[doc_id]
-        )
+        equipment_classes = {
+            'appliance': appliances_by_doc[doc_id],
+            'utensil': utensils_by_doc[doc_id],
+            'vessel': vessels_by_doc[doc_id],
+        }
         terms = []
-        for equipment in equipment:
-            terms.append(next(tokenize(equipment, stemmer=stemmer)))
+        term_attributes = {}
+        for equipment_class in equipment_classes:
+            for equipment in equipment_classes[equipment_class]:
+                term = next(tokenize(equipment, stemmer=stemmer))
+                terms.append(term)
+                term_attributes[term] = {'class': equipment_class}
         markup_by_doc[doc_id] = highlight(
             query=description,
             terms=terms,
             stemmer=stemmer,
-            case_sensitive=False
+            case_sensitive=False,
+            term_attributes=term_attributes
         )
 
     results = []


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In order to more easily represent and reason about the entities contained within each recipe direction line, it's important to know the object type that each match relates to.

For that reason, instead of returning markup that contains `fry the <mark>onions</mark> in the <mark>frying pan</mark>`, it would be more informative to respond with `fry the <mark class="ingredient">onions</mark> in the <mark class="vessel">frying pan</mark>`.

### Briefly summarize the changes
1. Update to `hashedixsearch==0.2.7` for [custom attribute rendering](https://github.com/openculinary/hashedixsearch/pull/24) support
1. Render per-equipment-type class information in API responses

### How have the changes been tested?
1. Test coverage is updated