### PR TITLE
Refactor: equipment endpoint: remove per-entity response fields

### DIFF
--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -19,7 +19,7 @@ def test_description_parsing(client):
     }
 
     response = client.post(
-        '/equipment/query',
+        '/directions/query',
         data={'descriptions[]': list(description_markup.keys())}
     )
     for result in response.json:

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -1,42 +1,27 @@
 def test_description_parsing(client):
-    description_equipment = {
-        'Pre-heat the oven to 250 degrees F.': {
-            'markup': (
-                'Pre-heat the <mark class="appliance">oven</mark> '
-                'to 250 degrees F.'
-            ),
-            'appliances': [{'appliance': 'oven'}],
-        },
-        'leave the Slow cooker on a low heat': {
-            'markup': (
-                'leave the <mark class="appliance">Slow cooker</mark> '
-                'on a low heat'
-            ),
-            'appliances': [{'appliance': 'slow cooker'}],
-        },
-        'place casserole dish in oven': {
-            'markup': (
-                'place <mark class="vessel">casserole dish</mark> '
-                'in <mark class="appliance">oven</mark>'
-            ),
-            'appliances': [{'appliance': 'oven'}],
-            'vessels': [{'vessel': 'casserole dish'}],
-        },
-        'empty skewer into the karahi': {
-            'markup': (
-                'empty <mark class="utensil">skewer</mark> into the '
-                '<mark class="vessel">karahi</mark>'
-            ),
-            'utensils': [{'utensil': 'skewer'}],
-            'vessels': [{'vessel': 'karahi'}],
-        },
+    description_markup = {
+        'Pre-heat the oven to 250 degrees F.': (
+            'Pre-heat the <mark class="equipment appliance">oven</mark> '
+            'to 250 degrees F.'
+        ),
+        'leave the Slow cooker on a low heat': (
+            'leave the <mark class="equipment appliance">Slow cooker </mark> '
+            'on a low heat'
+        ),
+        'place casserole dish in oven': (
+            'place <mark class="equipment vessel">casserole dish</mark> '
+            'in <mark class="equipment appliance">oven</mark>'
+        ),
+        'empty skewer into the karahi': (
+            'empty <mark class="equipment utensil">skewer</mark> into the '
+            '<mark class="equipment vessel">karahi</mark>'
+        ),
     }
 
     response = client.post(
         '/equipment/query',
-        data={'descriptions[]': list(description_equipment.keys())}
+        data={'descriptions[]': list(description_markup.keys())}
     )
     for result in response.json:
-        assert result['description'] in description_equipment
-        for key, value in description_equipment[result['description']].items():
-            assert result[key] == value
+        assert result['description'] in description_markup
+        assert result['markup'] == description_markup[result['description']]

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -5,7 +5,7 @@ def test_description_parsing(client):
             'to 250 degrees F.'
         ),
         'leave the Slow cooker on a low heat': (
-            'leave the <mark class="equipment appliance">Slow cooker </mark> '
+            'leave the <mark class="equipment appliance">Slow cooker</mark> '
             'on a low heat'
         ),
         'place casserole dish in oven': (

--- a/web/app.py
+++ b/web/app.py
@@ -3,5 +3,5 @@ from flask import Flask
 app = Flask(__name__)
 
 
-import web.equipment
+import web.directions
 import web.ingredients

--- a/web/directions.py
+++ b/web/directions.py
@@ -49,7 +49,7 @@ def matches_by_document(index, queries, stemmer):
     return results_by_document
 
 
-@app.route('/equipment/query', methods=['POST'])
+@app.route('/directions/query', methods=['POST'])
 def equipment():
     descriptions = request.form.getlist('descriptions[]')
 

--- a/web/equipment.py
+++ b/web/equipment.py
@@ -35,18 +35,17 @@ def preload_equipment_data():
     app.vessel_queries = load_queries(CACHE_PATHS['vessel_queries'])
 
 
-def equipment_by_document(index, queries):
+def matches_by_document(index, queries, stemmer):
     results_by_document = defaultdict(lambda: set())
-    stemmer = EquipmentStemmer()
-    equipment_hits = execute_queries(
+    query_hits = execute_queries(
         index=index,
         queries=queries,
         stemmer=stemmer,
         stopwords=stopwords
     )
-    for equipment, hits in equipment_hits:
+    for result, hits in query_hits:
         for hit in hits:
-            results_by_document[hit['doc_id']].add(equipment)
+            results_by_document[hit['doc_id']].add(result)
     return results_by_document
 
 
@@ -64,26 +63,39 @@ def equipment():
                                  stemmer=stemmer):
                 index.add_term_occurrence(term, doc_id)
 
-    appliances_by_doc = equipment_by_document(index, app.appliance_queries)
-    utensils_by_doc = equipment_by_document(index, app.utensil_queries)
-    vessels_by_doc = equipment_by_document(index, app.vessel_queries)
+    query_matrix = {
+        'equipment': {
+            'appliance': app.appliance_queries,
+            'utensil': app.utensil_queries,
+            'vessel': app.vessel_queries,
+        },
+    }
 
+    # Run the query matrix against the document set and collect entities by doc
+    entities_by_doc = defaultdict(list)
+    for entity_type in query_matrix:
+        for entity_class in query_matrix[entity_type]:
+            queries = query_matrix[entity_type][entity_class]
+            queries_by_doc = matches_by_document(index, queries, stemmer)
+            for doc_id, queries in queries_by_doc.items():
+                for query in queries:
+                    term = next(tokenize(query, stemmer=stemmer))
+                    entities_by_doc[doc_id].append({
+                        'term': term,
+                        'attr': {'class': f'{entity_type} {entity_class}'},
+                    })
+
+    # Collect all entities for each document and then generate doc markup
     markup_by_doc = {}
-    for doc_id, description in enumerate(descriptions):
-        equipment_classes = {
-            'appliance': appliances_by_doc[doc_id],
-            'utensil': utensils_by_doc[doc_id],
-            'vessel': vessels_by_doc[doc_id],
-        }
+    for doc_id, entities in entities_by_doc.items():
         terms = []
         term_attributes = {}
-        for equipment_class in equipment_classes:
-            for equipment in equipment_classes[equipment_class]:
-                term = next(tokenize(equipment, stemmer=stemmer))
-                terms.append(term)
-                term_attributes[term] = {'class': equipment_class}
+        for entity in entities:
+            term, attr = entity['term'], entity['attr']
+            terms.append(term)
+            term_attributes[term] = attr
         markup_by_doc[doc_id] = highlight(
-            query=description,
+            query=descriptions[doc_id],
             terms=terms,
             stemmer=stemmer,
             case_sensitive=False,
@@ -96,17 +108,5 @@ def equipment():
             'index': doc_id,
             'description': description,
             'markup': markup_by_doc.get(doc_id),
-            'appliances': [
-                {'appliance': appliance}
-                for appliance in appliances_by_doc[doc_id]
-            ],
-            'utensils': [
-                {'utensil': utensil}
-                for utensil in utensils_by_doc[doc_id]
-            ],
-            'vessels': [
-                {'vessel': vessel}
-                for vessel in vessels_by_doc[doc_id]
-            ],
         })
     return jsonify(results)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The number of entity types that will be included in the knowledge graph's `/equipment/query` -- possibly a misnomer for a `/directions/query` -- endpoint API response will soon increase, and in the short term it seems to make sense to bundle more of this content into the `markup` returned for each parsed text input.

Longer term it will make sense for the markup to include `id` reference attributes, and for the response to include metadata about each of the associated items; a few more steps are required before we can reach that point.

### Briefly summarize the changes
1. Refactor the `/equipment/query` endpoint to include inline entity information inside the `markup` response field
1. Rename the `/equipment/query` endpoint to `/directions/query`

### How have the changes been tested?
1. Unit test coverage is updated