### PR TITLE
Incorporate ingredient nutritional information from ingreedy-data

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
+exclude=web/data
 per-file-ignores=
     web/app.py:E402,F401

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "web/data/external/ingreedy-data"]
+	path = web/data/external/ingreedy-data
+	url = https://github.com/tomwhite/ingreedy-data.git

--- a/scripts/hierarchy.py
+++ b/scripts/hierarchy.py
@@ -55,7 +55,7 @@ graph.filter_products()
 
 def node_nutrition(graph, node):
     if node.nutrition_key:
-        return graph.nutrition_by_key[node.nutrition_key]
+        return graph.nutrition_by_id[node.nutrition_key]
     elif node.parent_id:
         return node_nutrition(graph, graph.products_by_id[node.parent_id])
 

--- a/scripts/hierarchy.py
+++ b/scripts/hierarchy.py
@@ -5,7 +5,7 @@ import sys
 from web.loader import (
     CACHE_PATHS,
     retrieve_products,
-    retrieve_nutrition,
+    retrieve_nutrition_list,
     retrieve_stopwords,
     write_items,
 )
@@ -41,7 +41,7 @@ parser.add_argument(
 args = parser.parse_args()
 
 products = retrieve_products(args.products)
-nutrition = retrieve_nutrition(args.nutrition)
+nutrition = retrieve_nutrition_list(args.nutrition)
 stopwords = retrieve_stopwords(args.stopwords)
 
 graph = ProductGraph(products, stopwords)

--- a/scripts/hierarchy.py
+++ b/scripts/hierarchy.py
@@ -60,24 +60,28 @@ def node_nutrition(graph, node):
         return node_nutrition(graph, graph.products_by_id[node.parent_id])
 
 
-def node_explorer(graph, node, path):
+def node_visitor(graph, node, path):
     for child_id in node.children:
         if child_id in path:
             continue
         child = graph.products_by_id[child_id]
         if child.parent_id == node.id:
             yield child
-            for child in node_explorer(graph, child, path + [child_id]):
+            for child in node_visitor(graph, child, path + [child_id]):
                 yield child
 
 
-def graph_explorer(graph):
+def graph_visitor(graph):
     for root in graph.roots:
-        root.nutrition = node_nutrition(graph, root)
         yield root
-        for node in node_explorer(graph, root, [root.id]):
-            node.nutrition = node_nutrition(graph, node)
+        for node in node_visitor(graph, root, [root.id]):
             yield node
+
+
+def graph_nodes(graph):
+    for node in graph_visitor(graph):
+        node.nutrition = node_nutrition(graph, node)
+        yield node
 
 
 if __name__ == '__main__':
@@ -85,5 +89,5 @@ if __name__ == '__main__':
     if args.update:
         Path(args.hierarchy).parent.mkdir(parents=True, exist_ok=True)
         output = open(args.hierarchy, 'w')
-    write_items(graph_explorer(graph), output)
+    write_items(graph_nodes(graph), output)
     output.close()

--- a/scripts/nutrition.py
+++ b/scripts/nutrition.py
@@ -1,0 +1,33 @@
+import argparse
+from pathlib import Path
+import sys
+
+from web.loader import (
+    CACHE_PATHS,
+    retrieve_nutrition,
+    write_items,
+)
+
+
+parser = argparse.ArgumentParser(description='Generate nutrition data')
+parser.add_argument(
+    '--nutrition',
+    default=CACHE_PATHS['nutrition'],
+    help='Cached nutrition file to read/write'
+)
+parser.add_argument(
+    '--update',
+    action='store_true',
+    help='Update cached content'
+)
+args = parser.parse_args()
+
+nutrition = list(retrieve_nutrition())
+
+if __name__ == '__main__':
+    output = sys.stdout
+    if args.update:
+        Path(args.nutrition).parent.mkdir(parents=True, exist_ok=True)
+        output = open(args.nutrition, 'w')
+    write_items(nutrition, output)
+    output.close()

--- a/scripts/nutrition.py
+++ b/scripts/nutrition.py
@@ -1,12 +1,20 @@
 import argparse
+import json
+import os
 from pathlib import Path
 import sys
 
 from web.loader import (
     CACHE_PATHS,
-    retrieve_nutrition,
     write_items,
 )
+from web.models.nutrition import Nutrition
+
+NUTRITION_PATHS = {
+    'lookup': 'web/data/external/ingreedy-data/data/processed/foodmap.json',
+    'mccance': 'web/data/external/ingreedy-data/data/processed/mccance.json',
+    'usfdc': 'web/data/external/ingreedy-data/data/processed/usfdc.json',
+}
 
 
 parser = argparse.ArgumentParser(description='Generate nutrition data')
@@ -22,12 +30,54 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-nutrition = list(retrieve_nutrition())
+
+def source_nutrition():
+    lookup = NUTRITION_PATHS['lookup']
+    if not os.path.exists(lookup):
+        raise RuntimeError(f'Could not read nutrition lookup from: {lookup}')
+    with open(lookup) as f:
+        lookup = json.loads(f.read())
+
+    mccance = NUTRITION_PATHS['mccance']
+    if not os.path.exists(mccance):
+        raise RuntimeError(f'Could not read mccance nutrition from: {mccance}')
+    with open(mccance) as f:
+        mccance = json.loads(f.read())
+        mccance = {item["name"]: item for item in mccance}
+
+    usfdc = NUTRITION_PATHS['usfdc']
+    if not os.path.exists(usfdc):
+        raise RuntimeError(f'Could not read usfdc nutrition from: {usfdc}')
+    with open(usfdc) as f:
+        usfdc = json.loads(f.read())
+        usfdc = {item["name"]: item for item in usfdc}
+
+    for metadata in lookup:
+        nutrition = None
+        product = metadata["normalized_name"]
+        datasets = {"food": mccance, "food_usfdc": usfdc}
+        for key, dataset in datasets.items():
+            name = metadata[key]
+            if name and name in dataset:
+                nutrition = dataset[name]
+                break
+        if not nutrition:
+            continue
+        yield Nutrition(
+            product=product,
+            fat=nutrition["fat"],
+            protein=nutrition["protein"],
+            carbohydrates=nutrition["carbs"],
+            energy=nutrition.get("energy") or nutrition.get("cals"),
+            fibre=nutrition["fibre"],
+        )
+
 
 if __name__ == '__main__':
     output = sys.stdout
     if args.update:
         Path(args.nutrition).parent.mkdir(parents=True, exist_ok=True)
         output = open(args.nutrition, 'w')
+    nutrition = source_nutrition()
     write_items(nutrition, output)
     output.close()

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -12,7 +12,6 @@ from web.app import app
 from web.loader import (
     CACHE_PATHS,
     retrieve_hierarchy,
-    retrieve_nutrition,
     retrieve_stopwords,
 )
 from web.models.product import Product
@@ -27,10 +26,7 @@ def preload_ingredient_data():
     filename = CACHE_PATHS['stopwords']
     stopwords = retrieve_stopwords(filename)
 
-    filename = CACHE_PATHS['nutrition']
-    nutrition = retrieve_nutrition(filename)
-
-    app.graph = ProductGraph(hierarchy, stopwords, nutrition)
+    app.graph = ProductGraph(hierarchy, stopwords)
     app.products = app.graph.filter_products()
     app.stopwords = app.graph.filter_stopwords()
 

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -12,6 +12,7 @@ from web.app import app
 from web.loader import (
     CACHE_PATHS,
     retrieve_hierarchy,
+    retrieve_nutrition,
     retrieve_stopwords,
 )
 from web.models.product import Product
@@ -26,7 +27,10 @@ def preload_ingredient_data():
     filename = CACHE_PATHS['stopwords']
     stopwords = retrieve_stopwords(filename)
 
-    app.graph = ProductGraph(hierarchy, stopwords)
+    filename = CACHE_PATHS['nutrition']
+    nutrition = retrieve_nutrition(filename)
+
+    app.graph = ProductGraph(hierarchy, stopwords, nutrition)
     app.products = app.graph.filter_products()
     app.stopwords = app.graph.filter_stopwords()
 

--- a/web/loader.py
+++ b/web/loader.py
@@ -150,7 +150,7 @@ def retrieve_nutrition():
         raise RuntimeError(f'Could not read usfdc nutrition from: {usfdc}')
     with open(usfdc) as f:
         usfdc = json.loads(f.read())
-        mccance = {item["name"]: item for item in usfdc}
+        usfdc = {item["name"]: item for item in usfdc}
 
     for metadata in lookup:
         nutrition = None

--- a/web/loader.py
+++ b/web/loader.py
@@ -19,12 +19,6 @@ CACHE_PATHS = {
     'vessel_queries': 'web/data/equipment/vessels.txt',
 }
 
-NUTRITION_PATHS = {
-    'lookup': 'web/data/external/ingreedy-data/data/processed/foodmap.json',
-    'mccance': 'web/data/external/ingreedy-data/data/processed/mccance.json',
-    'usfdc': 'web/data/external/ingreedy-data/data/processed/usfdc.json',
-}
-
 
 def load_queries(filename):
     with open(filename) as f:
@@ -132,46 +126,17 @@ def retrieve_hierarchy(filename):
             )
 
 
-def retrieve_nutrition():
-    lookup = NUTRITION_PATHS['lookup']
-    if not os.path.exists(lookup):
-        raise RuntimeError(f'Could not read nutrition lookup from: {lookup}')
-    with open(lookup) as f:
-        lookup = json.loads(f.read())
+def retrieve_nutrition(filename):
+    if not os.path.exists(filename):
+        raise RuntimeError(f'Could not read nutrition from: {filename}')
 
-    mccance = NUTRITION_PATHS['mccance']
-    if not os.path.exists(mccance):
-        raise RuntimeError(f'Could not read mccance nutrition from: {mccance}')
-    with open(mccance) as f:
-        mccance = json.loads(f.read())
-        mccance = {item["name"]: item for item in mccance}
-
-    usfdc = NUTRITION_PATHS['usfdc']
-    if not os.path.exists(usfdc):
-        raise RuntimeError(f'Could not read usfdc nutrition from: {usfdc}')
-    with open(usfdc) as f:
-        usfdc = json.loads(f.read())
-        usfdc = {item["name"]: item for item in usfdc}
-
-    for metadata in lookup:
-        nutrition = None
-        product = metadata["normalized_name"]
-        datasets = {"food": mccance, "food_usfdc": usfdc}
-        for key, dataset in datasets.items():
-            name = metadata[key]
-            if name and name in dataset:
-                nutrition = dataset[name]
-                break
-        if not nutrition:
-            continue
-        yield Nutrition(
-            product=product,
-            fat=nutrition["fat"],
-            protein=nutrition["protein"],
-            carbohydrates=nutrition["carbs"],
-            energy=nutrition.get("energy") or nutrition.get("cals"),
-            fibre=nutrition["fibre"],
-        )
+    print(f'Reading nutrition from {filename}')
+    with open(filename) as f:
+        for line in f.readlines():
+            if line.startswith('#'):
+                continue
+            nutrition = json.loads(line)
+            yield Nutrition(**nutrition)
 
 
 def write_items(items, output):

--- a/web/loader.py
+++ b/web/loader.py
@@ -122,15 +122,16 @@ def retrieve_hierarchy(filename):
             yield Product(
                 name=product['product'],
                 frequency=product['recipe_count'],
-                parent_id=product.get('parent_id')
+                parent_id=product.get('parent_id'),
+                nutrition=product.get('nutrition')
             )
 
 
-def retrieve_nutrition(filename):
+def retrieve_nutrition_list(filename):
     if not os.path.exists(filename):
-        raise RuntimeError(f'Could not read nutrition from: {filename}')
+        raise RuntimeError(f'Could not read nutrition list from: {filename}')
 
-    print(f'Reading nutrition from {filename}')
+    print(f'Reading nutrition list from {filename}')
     with open(filename) as f:
         for line in f.readlines():
             if line.startswith('#'):

--- a/web/loader.py
+++ b/web/loader.py
@@ -168,7 +168,7 @@ def retrieve_nutrition():
             fat=nutrition["fat"],
             protein=nutrition["protein"],
             carbohydrates=nutrition["carbs"],
-            energy=nutrition["energy"],
+            energy=nutrition.get("energy") or nutrition.get("cals"),
             fibre=nutrition["fibre"],
         )
 

--- a/web/loader.py
+++ b/web/loader.py
@@ -12,6 +12,7 @@ from web.models.product import Product
 CACHE_PATHS = {
     'hierarchy': 'web/data/generated/hierarchy.json',
     'products': 'web/data/generated/ingredients.json',
+    'nutrition': 'web/data/generated/nutrition.json',
     'stopwords': 'web/data/generated/stopwords.txt',
     'appliance_queries': 'web/data/equipment/appliances.txt',
     'utensil_queries': 'web/data/equipment/utensils.txt',

--- a/web/models/nutrition.py
+++ b/web/models/nutrition.py
@@ -1,5 +1,6 @@
 import json
 
+
 class Nutrition(object):
 
     def __init__(self, product, protein, fat, carbohydrates, energy, fibre):

--- a/web/models/nutrition.py
+++ b/web/models/nutrition.py
@@ -1,0 +1,4 @@
+class Nutrition(object):
+
+    def __init__(self, product, protein, fat, carbohydrates, energy, fibre):
+        pass

--- a/web/models/nutrition.py
+++ b/web/models/nutrition.py
@@ -1,5 +1,11 @@
 import json
 
+from hashedixsearch import (
+    tokenize,
+)
+
+from web.models.product import Product
+
 
 class Nutrition(object):
 
@@ -12,11 +18,21 @@ class Nutrition(object):
         self.fibre = fibre
 
     def __repr__(self):
-        return json.dumps({
+        return json.dumps(self.to_dict())
+
+    def to_dict(self):
+        return {
             'product': self.product,
             'protein': self.protein,
             'fat': self.fat,
             'carbohydrates': self.carbohydrates,
             'energy': self.energy,
             'fibre': self.fibre,
-        })
+        }
+
+    def tokenize(self, stopwords=True, stemmer=True, analyzer=True):
+        for term in tokenize(doc=self.product, stemmer=Product.stemmer):
+            for subterm in term:
+                yield subterm
+            if len(term) > 1:
+                return

--- a/web/models/nutrition.py
+++ b/web/models/nutrition.py
@@ -4,8 +4,6 @@ from hashedixsearch import (
     tokenize,
 )
 
-from web.models.product import Product
-
 
 class Nutrition(object):
 
@@ -31,6 +29,7 @@ class Nutrition(object):
         }
 
     def tokenize(self, stopwords=True, stemmer=True, analyzer=True):
+        from web.models.product import Product
         for term in tokenize(doc=self.product, stemmer=Product.stemmer):
             for subterm in term:
                 yield subterm

--- a/web/models/nutrition.py
+++ b/web/models/nutrition.py
@@ -1,4 +1,21 @@
+import json
+
 class Nutrition(object):
 
     def __init__(self, product, protein, fat, carbohydrates, energy, fibre):
-        pass
+        self.product = product
+        self.protein = protein
+        self.fat = fat
+        self.carbohydrates = carbohydrates
+        self.energy = energy
+        self.fibre = fibre
+
+    def __repr__(self):
+        return json.dumps({
+            'product': self.product,
+            'protein': self.protein,
+            'fat': self.fat,
+            'carbohydrates': self.carbohydrates,
+            'energy': self.energy,
+            'fibre': self.fibre,
+        })

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -36,7 +36,6 @@ class Product(object):
         self.stopwords = []
         self.domain = None
 
-        self.nutrition_doc_ids = []
         self.nutrition_key = nutrition_key
         self.nutrition = None
 

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -38,6 +38,7 @@ class Product(object):
 
         self.nutrition_doc_ids = []
         self.nutrition_key = nutrition_key
+        self.nutrition = None
 
         # TODO: Find a better place to perform this initialization
         if self.canonicalizations:
@@ -56,10 +57,13 @@ class Product(object):
         return self
 
     def __repr__(self):
-        data = self.to_dict(include_hierarchy=self.children or self.parents)
+        data = self.to_dict(
+            include_hierarchy=self.children or self.parents,
+            include_nutrition=self.nutrition
+        )
         return '  ' * (self.depth or 0) + json.dumps(data, ensure_ascii=False)
 
-    def to_dict(self, include_hierarchy=False):
+    def to_dict(self, include_hierarchy=False, include_nutrition=False):
         data = {
             'product': self.name,
             'recipe_count': self.frequency
@@ -70,6 +74,10 @@ class Product(object):
                 'domain': self.domain,
                 'parent_id': self.parent_id,
                 'depth': self.depth
+            })
+        if include_nutrition and self.nutrition:
+            data.update({
+                'nutrition': self.nutrition.to_dict()
             })
         return data
 

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -57,13 +57,10 @@ class Product(object):
         return self
 
     def __repr__(self):
-        data = self.to_dict(
-            include_hierarchy=self.children or self.parents,
-            include_nutrition=self.nutrition
-        )
+        data = self.to_dict(include_hierarchy=self.children or self.parents)
         return '  ' * (self.depth or 0) + json.dumps(data, ensure_ascii=False)
 
-    def to_dict(self, include_hierarchy=False, include_nutrition=False):
+    def to_dict(self, include_hierarchy=False):
         data = {
             'product': self.name,
             'recipe_count': self.frequency
@@ -75,7 +72,7 @@ class Product(object):
                 'parent_id': self.parent_id,
                 'depth': self.depth
             })
-        if include_nutrition and self.nutrition:
+        if self.nutrition:
             data.update({
                 'nutrition': self.nutrition.to_dict()
             })

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -25,7 +25,7 @@ class Product(object):
     canonicalizations = {}
     inflector = inflect.engine()
 
-    def __init__(self, name, frequency=0, parent_id=None):
+    def __init__(self, name, frequency=0, parent_id=None, nutrition_key=None):
         self.name = name
         self.frequency = frequency
         self.parent_id = parent_id
@@ -35,6 +35,9 @@ class Product(object):
         self.parents = []
         self.stopwords = []
         self.domain = None
+
+        self.nutrition_doc_ids = []
+        self.nutrition_key = nutrition_key
 
         # TODO: Find a better place to perform this initialization
         if self.canonicalizations:

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -25,7 +25,7 @@ class Product(object):
     canonicalizations = {}
     inflector = inflect.engine()
 
-    def __init__(self, name, frequency=0, parent_id=None, nutrition_key=None):
+    def __init__(self, name, frequency=0, parent_id=None):
         self.name = name
         self.frequency = frequency
         self.parent_id = parent_id
@@ -36,8 +36,8 @@ class Product(object):
         self.stopwords = []
         self.domain = None
 
-        self.nutrition_key = nutrition_key
         self.nutrition = None
+        self.nutrition_key = None
 
         # TODO: Find a better place to perform this initialization
         if self.canonicalizations:

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -8,6 +8,8 @@ import json
 from snowballstemmer import stemmer
 from unidecode import unidecode
 
+from web.models.nutrition import Nutrition
+
 
 class Product(object):
 
@@ -25,7 +27,7 @@ class Product(object):
     canonicalizations = {}
     inflector = inflect.engine()
 
-    def __init__(self, name, frequency=0, parent_id=None):
+    def __init__(self, name, frequency=0, parent_id=None, nutrition=None):
         self.name = name
         self.frequency = frequency
         self.parent_id = parent_id
@@ -36,8 +38,8 @@ class Product(object):
         self.stopwords = []
         self.domain = None
 
-        self.nutrition = None
-        self.nutrition_key = None
+        self.nutrition = Nutrition(**nutrition) if nutrition else None
+        self.nutrition_key = self.nutrition.product if self.nutrition else None
 
         # TODO: Find a better place to perform this initialization
         if self.canonicalizations:

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -17,7 +17,6 @@ class ProductGraph(object):
         self.stopwords = list(self.process_stopwords(stopwords))
         self.stopword_index = self.build_stopword_index()
         self.nutrition_by_id = {}
-        self.nutrition_by_key = {}
         self.nutrition_index = self.build_nutrition_index(nutrition)
         self.roots = []
 
@@ -84,7 +83,7 @@ class ProductGraph(object):
 
     def build_nutrition_index(self, nutrition):
         index = build_search_index()
-        for doc_id, nutrition in enumerate(nutrition or []):
+        for nutrition in nutrition or []:
             product = Product(name=nutrition.product)
             for term in tokenize(
                 doc=product.name,
@@ -95,9 +94,8 @@ class ProductGraph(object):
                 if stopword_id is not None:
                     product.stopwords.append(self.stopwords[stopword_id])
             if tokenize(product.name, product.stopwords):
-                self.nutrition_by_id[doc_id] = nutrition
-                self.nutrition_by_key[product.name] = nutrition
-                add_to_search_index(index, doc_id, product.to_doc())
+                self.nutrition_by_id[product.name] = nutrition
+                add_to_search_index(index, product.name, product.to_doc())
         return index
 
     def get_byproducts(self):

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -139,11 +139,6 @@ class ProductGraph(object):
             for parent in self.find_parents(parent):
                 yield parent
 
-    def find_nutrition(self, product):
-        hits = execute_query(self.nutrition_index, product.to_doc())
-        for hit in hits:
-            yield hit['doc_id']
-
     def build_relationships(self):
 
         # Assign byproducts to their parent ingredients
@@ -212,9 +207,9 @@ class ProductGraph(object):
         for product in self.products_by_id.values():
 
             # Find the top-scoring nutrition match
-            doc_id = next(self.find_nutrition(product), None)
-            if doc_id:
-                nutrition = self.nutrition_by_id[doc_id]
+            hits = execute_query(self.nutrition_index, product.to_doc())
+            if hits:
+                nutrition = self.nutrition_by_id[hits[0]['doc_id']]
                 product.nutrition_key = nutrition.product
 
     def calculate_depth(self):

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -90,9 +90,9 @@ class ProductGraph(object):
                 ngrams=1,
                 stemmer=Product.stemmer
             ):
-                stopword_id = execute_query_exact(self.stopword_index, term)
-                if stopword_id is not None:
-                    product.stopwords.append(self.stopwords[stopword_id])
+                doc_id = execute_query_exact(self.stopword_index, term)
+                if doc_id is not None:
+                    product.stopwords.append(self.stopwords[doc_id])
             if tokenize(product.name, product.stopwords):
                 self.nutrition_by_id[product.name] = nutrition
                 add_to_search_index(index, product.name, product.to_doc())

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -11,13 +11,13 @@ from web.models.product import Product
 
 class ProductGraph(object):
 
-    def __init__(self, products, stopwords=None, nutrition=None):
+    def __init__(self, products, stopwords=None, nutrition_list=None):
         self.products_by_id = {}
         self.index = self.build_index(products)
         self.stopwords = list(self.process_stopwords(stopwords))
         self.stopword_index = self.build_stopword_index()
         self.nutrition_by_id = {}
-        self.nutrition_index = self.build_nutrition_index(nutrition)
+        self.nutrition_index = self.build_nutrition_index(nutrition_list)
         self.roots = []
 
     def generate_hierarchy(self):
@@ -81,9 +81,9 @@ class ProductGraph(object):
             add_to_search_index(index, doc_id, stopword)
         return index
 
-    def build_nutrition_index(self, nutrition):
+    def build_nutrition_index(self, nutrition_list):
         index = build_search_index()
-        for nutrition in nutrition or []:
+        for nutrition in nutrition_list or []:
             product = Product(name=nutrition.product)
             for term in tokenize(
                 doc=product.name,

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -23,7 +23,7 @@ class ProductGraph(object):
     def generate_hierarchy(self):
         self.build_relationships()
         self.assign_parents()
-        self.assign_nutrition()
+        self.match_nutrition()
         self.calculate_depth()
         return self.roots
 
@@ -202,7 +202,7 @@ class ProductGraph(object):
             if primary_parent:
                 product.parent_id = primary_parent.id
 
-    def assign_nutrition(self):
+    def match_nutrition(self):
         # Find nutritional information for each product in the graph
         for product in self.products_by_id.values():
 

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -94,8 +94,9 @@ class ProductGraph(object):
                 if doc_id is not None:
                     product.stopwords.append(self.stopwords[doc_id])
             if tokenize(product.name, product.stopwords):
-                self.nutrition_by_id[product.name] = nutrition
                 add_to_search_index(index, product.name, product.to_doc())
+                if product.name not in self.nutrition_by_id:
+                    self.nutrition_by_id[product.name] = nutrition
         return index
 
     def get_byproducts(self):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset adds a reference to the [`ingreedy-data`](https://github.com/tomwhite/ingreedy-data) dataset, which contains consolidated nutritional information from multiple sources including the UK CoFID (aka 'McCance') and the US FoodData Central databases.

In order to perform matching between the RecipeRadar dataset and `ingreedy-data`, we use the `normalized_name` field from the latter's consolidated JSON format and build a search index using the names as documents.  For each named ingredient in RecipeRadar, a query is performed on the search index and the best-matching result is selected.

If no matches are found and the RecipeRadar ingredient has a 'parent' (i.e. `tofu` is the parent of `firm tofu`), then nutritional information from the parent element is used as a fallback where present.

Matching accuracy hasn't yet been scrutinized or quantified and this algorithm will likely require further development and improvements.

### Briefly summarize the changes
1. Add a git submodule reference to `ingreedy-data`
1. Weave data together from each of the root, McCance and FDC `ingreedy-data` JSON files
1. Build a search index and perform query-based ingredient nutrition matching
1. Update the `hierarchy.json` output document to include nutritional information

### How have the changes been tested?
1. Manual testing and inspection

**List any issues that this change relates to**
Relates to the RecipeRadar [Q3 2020 roadmap](https://github.com/openculinary/company/blob/main/roadmap/reciperadar.md#q3-2020).

cc @tomwhite