### PR TITLE
Include product nutrition metadata in ingredient query response

### DIFF
--- a/web/models/product.py
+++ b/web/models/product.py
@@ -133,6 +133,7 @@ class Product(object):
             'category': self.category,
             'contents': self.contents,
             'ancestors': [ancestor.name for ancestor in self.ancestry(graph)],
+            'nutrition': self.nutrition.to_dict() if self.nutrition else None,
         }
 
     def ancestry(self, graph):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In changeset #48, nutritional information was added into the ingredient product knowledge base.  This follow-up change includes nutritional information in the metadata response included during ingredient queries.

### Briefly summarize the changes
1. Include nutritional metadata in the ingredient query API response

### How have the changes been tested?
1. Unit test coverage is provided