### PR TITLE
Add boolean properties (vegan, vegetarian, ...) to individual ingredient metadata

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -153,25 +153,25 @@ def test_product_categories(name, category):
 
 def dietary_property_cases():
     return [
-        ('beef', False, True, False, True),
-        ('chicken', False, True, False, True),
+        ('beef', True, True, False, False),
+        ('chicken', True, True, False, False),
         ('tofu', True, True, True, True),
-        ('egg', True, False, False, True),
+        ('egg', False, True, False, True),
     ]
 
 
 @pytest.mark.parametrize(
-    "name,vegetarian,dairy_free,vegan,gluten_free",
+    "name,dairy_free,gluten_free,vegan,vegetarian",
     dietary_property_cases()
 )
-def test_product_dietary_properties(name, vegetarian, dairy_free, vegan,
-                                    gluten_free):
+def test_product_dietary_properties(name, dairy_free, gluten_free, vegan,
+                                    vegetarian):
     product = Product(name=name)
 
-    assert product.is_vegetarian == vegetarian
     assert product.is_dairy_free == dairy_free
-    assert product.is_vegan == vegan
     assert product.is_gluten_free == gluten_free
+    assert product.is_vegan == vegan
+    assert product.is_vegetarian == vegetarian
 
 
 def canonicalization_cases():

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -156,6 +156,7 @@ def dietary_property_cases():
         ('beef', False, True, False, True),
         ('chicken', False, True, False, True),
         ('tofu', True, True, True, True),
+        ('egg', True, False, False, True),
     ]
 
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -151,6 +151,28 @@ def test_product_categories(name, category):
     assert product.category == category
 
 
+def dietary_property_cases():
+    return [
+        ('beef', False, True, False, True),
+        ('chicken', False, True, False, True),
+        ('tofu', True, True, True, True),
+    ]
+
+
+@pytest.mark.parametrize(
+    "name,vegetarian,dairy_free,vegan,gluten_free",
+    dietary_property_cases()
+)
+def test_product_dietary_properties(name, vegetarian, dairy_free, vegan,
+                                    gluten_free):
+    product = Product(name=name)
+
+    assert product.is_vegetarian == vegetarian
+    assert product.is_dairy_free == dairy_free
+    assert product.is_vegan == vegan
+    assert product.is_gluten_free == gluten_free
+
+
 def canonicalization_cases():
     return {
         'cod filet': 'cod fillet',

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -137,10 +137,10 @@ class Product(object):
             'ancestors': [ancestor.name for ancestor in self.ancestry(graph)],
             'nutrition': nutrition,
             'properties': {
-                'is_vegetarian': self.is_vegetarian,
                 'is_dairy_free': self.is_dairy_free,
-                'is_vegan': self.is_vegan,
                 'is_gluten_free': self.is_gluten_free,
+                'is_vegan': self.is_vegan,
+                'is_vegetarian': self.is_vegetarian,
             },
         }
 
@@ -240,16 +240,8 @@ class Product(object):
         return list(contents)
 
     @property
-    def is_vegetarian(self):
-        return 'meat' not in self.contents
-
-    @property
     def is_dairy_free(self):
         return self.category != 'dairy'
-
-    @property
-    def is_vegan(self):
-        return self.is_vegetarian and self.is_dairy_free
 
     @property
     def is_gluten_free(self):
@@ -270,3 +262,11 @@ class Product(object):
             if 'beer' in item:
                 likely_glutenous = True
         return not likely_glutenous
+
+    @property
+    def is_vegan(self):
+        return self.is_vegetarian and self.is_dairy_free
+
+    @property
+    def is_vegetarian(self):
+        return 'meat' not in self.contents

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -136,6 +136,12 @@ class Product(object):
             'contents': self.contents,
             'ancestors': [ancestor.name for ancestor in self.ancestry(graph)],
             'nutrition': nutrition,
+            'properties': {
+                'is_vegetarian': self.is_vegetarian,
+                'is_dairy_free': self.is_dairy_free,
+                'is_vegan': self.is_vegan,
+                'is_gluten_free': self.is_gluten_free,
+            },
         }
 
     def ancestry(self, graph):

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -245,7 +245,7 @@ class Product(object):
 
     @property
     def is_dairy_free(self):
-        return 'dairy' not in self.contents
+        return self.category != 'dairy'
 
     @property
     def is_vegan(self):

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -232,3 +232,35 @@ class Product(object):
                     singular = Product.inflector.singular_noun(field) or field
                     contents.add(singular)
         return list(contents)
+
+    @property
+    def is_vegetarian(self):
+        return 'meat' not in self.contents
+
+    @property
+    def is_dairy_free(self):
+        return 'dairy' not in self.contents
+
+    @property
+    def is_vegan(self):
+        return self.is_vegetarian and self.is_dairy_free
+
+    @property
+    def is_gluten_free(self):
+        likely_glutenous = False
+        for item in self.contents:
+            if 'flour' in item:
+                likely_glutenous = True
+            if 'bread' in item:
+                likely_glutenous = True
+            if 'pasta' in item:
+                likely_glutenous = True
+            if 'noodle' in item:
+                likely_glutenous = True
+            if 'soy sauce' in item:
+                likely_glutenous = True
+            if 'bouillon' in item:
+                likely_glutenous = True
+            if 'beer' in item:
+                likely_glutenous = True
+        return not likely_glutenous


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
For the purposes of searching and filtering recipes based on dietary requirements, it's important to know various boolean properties of each recipe - such as whether it is vegan or not.

Many of these properties are determined by assessing that same property against each of the individual component ingredients of the recipe.

This change adds four properties to each ingredient metadata response from the service:

- `is_dairy_free`
- `is_gluten_free`
- `is_vegan`
- `is_vegetarian`

### Briefly summarize the changes
1. Determine boolean properties of each ingredient based on naive logical rules
1. Include boolean property values in service response

### How have the changes been tested?
1. Unit test coverage is provided