### PR TITLE
[performance] Add caching for index-related operations

### DIFF
--- a/web/directions.py
+++ b/web/directions.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from functools import lru_cache
 import en_core_web_sm
 from flask import jsonify, request
 from hashedixsearch import (
@@ -22,6 +23,7 @@ class EquipmentStemmer(NullStemmer):
 
     stemmer_en = stemmer('english')
 
+    @lru_cache(maxsize=4096)
     def stem(self, x):
         return self.stemmer_en.stemWord(x)
 

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -91,7 +91,7 @@ def ingredients():
             synonyms=Product.canonicalizations,
             case_sensitive=False,
         )
-        metadata[doc_id] = product.get_metadata(description, app.graph, terms)
+        metadata[doc_id] = product.get_metadata(description, app.graph)
 
     return jsonify({
         'results': {

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -120,18 +120,15 @@ class Product(object):
         return depth
 
     @lru_cache(maxsize=4096)
-    def get_metadata(self, description, graph):
+    def _static_metadata(self, graph):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name
         plural = Product.inflector.plural_noun(singular)
-        is_plural = plural in description.lower()
         nutrition = self.nutrition.to_dict(include_product=False) \
             if self.nutrition else None
 
         return {
             'id': self.id,
-            'product': plural if is_plural else singular,
-            'is_plural': is_plural,
             'singular': singular,
             'plural': plural,
             'category': self.category,
@@ -143,6 +140,13 @@ class Product(object):
             'is_vegan': self.is_vegan,
             'is_vegetarian': self.is_vegetarian,
         }
+
+    def get_metadata(self, description, graph):
+        metadata = self._static_metadata(graph)
+        is_plural = metadata['plural'] in description.lower()
+        metadata['is_plural'] = is_plural
+        metadata['product'] = metadata['plural' if is_plural else 'singular']
+        return metadata
 
     def ancestry(self, graph):
         if not self.parent_id:

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -119,6 +119,7 @@ class Product(object):
         self.depth = depth
         return depth
 
+    @lru_cache(maxsize=4096)
     def get_metadata(self, description, graph):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -119,7 +119,7 @@ class Product(object):
         self.depth = depth
         return depth
 
-    def get_metadata(self, description, graph, terms=None):
+    def get_metadata(self, description, graph):
         singular = Product.inflector.singular_noun(self.name)
         singular = singular or self.name
         plural = Product.inflector.plural_noun(singular)

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 import json
 
 from hashedixsearch import (
@@ -16,6 +17,7 @@ class Product(object):
 
         stemmer_en = stemmer('english')
 
+        @lru_cache(maxsize=4096)
         def stem(self, x):
             x = unidecode(x)
             # TODO: Remove double-stemming


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As an experiment to improve response times and reduce workload for the service, add caching to methods that should be stable and return the same results over time.

### Briefly summarize the changes
1. Add caching for stemming-related operations
1. Separate product metadata into static and dynamic elements; cache the static elements

### How have the changes been tested?
1. Local development testing
