### PR TITLE
Provide the ability to manually assign products to parent products in the ingredient hierarchy

### DIFF
--- a/web/data/pinned-products.txt
+++ b/web/data/pinned-products.txt
@@ -1,0 +1,2 @@
+halibut steak,halibut
+root beer

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -191,9 +191,32 @@ class ProductGraph(object):
                     child.parents.append(parent.id)
                     parent.children.append(child_id)
 
+    def get_pinned_products(self):
+        pinned_products = {}
+        with open('web/data/pinned-products.txt') as f:
+            for line in f.readlines():
+                if line.startswith('#'):
+                    continue
+                line = line.strip().lower()
+                tokens = iter(line.split(','))
+                product = next(tokens)
+                product = Product(name=product)
+                parent = next(tokens, None)
+                parent = Product(name=parent) if parent else None
+                pinned_products[product.id] = parent
+        return pinned_products
+
     def assign_parents(self):
+        pinned_products = self.get_pinned_products()
+
         # Find a parent product for each product in the graph
         for product in self.products_by_id.values():
+
+            # Directly assign parent product for manually pinned products
+            if product.id in pinned_products:
+                if pinned_products[product.id]:
+                    product.parent_id = pinned_products[product.id].id
+                continue
 
             # Find the parent with the most tokens
             primary_parent = None


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The ingredient hierarchy is generated based on an algorithm that uses a search engine to allocate ingredient parents based on the idea that they will contain similar natural language text tokens.

In particular, assignment is generally made using the understanding that ingredient names may become 'more specific' -- for example, 'firm tofu' is a more specific variant of 'tofu.

However, there are cases where this automatic assignment makes mistakes.  One example is provided in #50 where 'tuna steak' was allocated as a child element of 'steak' -- where the latter currently tends to imply beef steak in most recipe documents.

This changeset provides a manual mechanism to re-allocate product parent assignment in the case where the automatic hierarchy assignment is incorrect.  This mechanism should be used sparingly.

### Briefly summarize the changes
1. Add a text file, `pinned-products.txt` that provides the ability to override the product parent for named products

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Fixes #50 