### PR TITLE
Add 'kitchen staple' product property

### DIFF
--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -151,28 +151,30 @@ def test_product_categories(name, category):
     assert product.category == category
 
 
-def dietary_property_cases():
+def product_property_cases():
     return [
-        ('beef', True, True, False, False),
-        ('chicken', True, True, False, False),
-        ('tofu', True, True, True, True),
-        ('egg', False, True, False, True),
-        ('tuna', True, True, False, False),
+        ('beef', True, True, False, False, False),
+        ('chicken', True, True, False, False, False),
+        ('tofu', True, True, True, True, False),
+        ('egg', False, True, False, True, True),
+        ('tuna', True, True, False, False, False),
+        ('salt', True, True, True, True, True),
     ]
 
 
 @pytest.mark.parametrize(
-    "name,dairy_free,gluten_free,vegan,vegetarian",
-    dietary_property_cases()
+    "name,dairy_free,gluten_free,vegan,vegetarian,kitchen_staple",
+    product_property_cases()
 )
-def test_product_dietary_properties(name, dairy_free, gluten_free, vegan,
-                                    vegetarian):
+def test_product_properties(name, dairy_free, gluten_free, vegan,
+                            vegetarian, kitchen_staple):
     product = Product(name=name)
 
     assert product.is_dairy_free == dairy_free
     assert product.is_gluten_free == gluten_free
     assert product.is_vegan == vegan
     assert product.is_vegetarian == vegetarian
+    assert product.is_kitchen_staple == kitchen_staple
 
 
 def canonicalization_cases():

--- a/web/models/product.py
+++ b/web/models/product.py
@@ -135,6 +135,7 @@ class Product(object):
             'contents': self.contents,
             'ancestors': [ancestor.name for ancestor in self.ancestry(graph)],
             'nutrition': nutrition,
+            'is_kitchen_staple': self.is_kitchen_staple,
             'is_dairy_free': self.is_dairy_free,
             'is_gluten_free': self.is_gluten_free,
             'is_vegan': self.is_vegan,
@@ -260,6 +261,25 @@ class Product(object):
                     singular = Product.inflector.singular_noun(field) or field
                     contents.add(singular)
         return list(contents)
+
+    @property
+    def is_kitchen_staple(self):
+        singular = Product.inflector.singular_noun(self.name) or self.name
+        # TODO: this list is fairly arbitrary; it was collected by querying for
+        # the most-commonly-occurring singular product names in the database
+        staples = {
+            'salt',
+            'butter',
+            'egg',
+            'olive oil',
+            'flour',
+            'onion',
+            'sugar',
+            'water',
+            'milk',
+            'brown sugar',
+        }
+        return singular in staples
 
     @property
     def is_dairy_free(self):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Add a naively-determined `is_kitchen_staple` flag to indicate that a product is very commonly available.

NB / sidenote: the term 'staple food' has another slightly different meaning relating to nutritional provision - a staple food is also considered to be one that provides a large portion of nutrition for a community.  It'd be good to figure out distinct terms for 'item that is frequently available in kitchens' vs 'item that provides significant widespread nutritional value'.