### PR TITLE
Recipe direction responses: include equipment items as named entities

### DIFF
--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -5,7 +5,7 @@ def test_description_parsing(client):
             'to 250 degrees F.'
         ),
         'leave the Slow cooker on a low heat': (
-            '<mark class="action">leave</mark> the '
+            '<mark class="verb action">leave</mark> the '
             '<mark class="equipment appliance">Slow cooker</mark> '
             'on a low heat'
         ),

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -31,7 +31,8 @@ def test_description_parsing(client):
         data={'descriptions[]': list(description_markup.keys())}
     )
     for result in response.json:
-        assert result['description'] in description_markup
-        assert result['markup'] == description_markup[result['description']]
-        assert result['description'] in description_entities
-        assert result['entities'] == description_entities[result['description']]
+        description = result['description']
+        assert description in description_markup
+        assert result['markup'] == description_markup[description]
+        assert description in description_entities
+        assert result['entities'] == description_entities[description]

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -34,5 +34,7 @@ def test_description_parsing(client):
         description = result['description']
         assert description in description_markup
         assert result['markup'] == description_markup[description]
+
+        entity_names = [entity['name'] for entity in result['entities']]
         assert description in description_entities
-        assert result['entities'] == description_entities[description]
+        assert entity_names == description_entities[description]

--- a/tests/test_directions.py
+++ b/tests/test_directions.py
@@ -19,6 +19,13 @@ def test_description_parsing(client):
         ),
     }
 
+    description_entities = {
+        'Pre-heat the oven to 250 degrees F.': ['oven'],
+        'leave the Slow cooker on a low heat': ['slow cooker'],
+        'place casserole dish in oven': ['oven', 'casserole dish'],
+        'empty skewer into the karahi': ['skewer', 'karahi'],
+    }
+
     response = client.post(
         '/directions/query',
         data={'descriptions[]': list(description_markup.keys())}
@@ -26,3 +33,5 @@ def test_description_parsing(client):
     for result in response.json:
         assert result['description'] in description_markup
         assert result['markup'] == description_markup[result['description']]
+        assert result['description'] in description_entities
+        assert result['entities'] == description_entities[result['description']]

--- a/web/directions.py
+++ b/web/directions.py
@@ -109,7 +109,7 @@ def equipment():
             'description': description,
             'markup': markup_by_doc.get(doc_id),
             'entities': [
-                entity['name']
+                {'name': entity['name']}
                 for entity in entities_by_doc.get(doc_id, [])
                 if entity.get('name') is not None
             ],

--- a/web/directions.py
+++ b/web/directions.py
@@ -63,8 +63,8 @@ def equipment():
     # Run the query matrix against the document set and collect entities by doc
     entities_by_doc = defaultdict(list)
     for entity_type in query_matrix:
-        for entity_class in query_matrix[entity_type]:
-            queries = query_matrix[entity_type][entity_class]
+        for entity_category in query_matrix[entity_type]:
+            queries = query_matrix[entity_type][entity_category]
             queries_by_doc = matches_by_document(index, queries, stemmer)
             for doc_id, queries in queries_by_doc.items():
                 for query in queries:
@@ -73,7 +73,7 @@ def equipment():
                         'name': query,
                         'term': term,
                         'type': entity_type,
-                        'category': entity_class,
+                        'category': entity_category,
                     })
 
     # Collect unique verbs found in each input description

--- a/web/directions.py
+++ b/web/directions.py
@@ -70,6 +70,7 @@ def equipment():
                 for query in queries:
                     term = next(index.tokenize(query))
                     entities_by_doc[doc_id].append({
+                        'name': query,
                         'term': term,
                         'attr': {'class': f'{entity_type} {entity_class}'},
                     })
@@ -107,5 +108,10 @@ def equipment():
             'index': doc_id,
             'description': description,
             'markup': markup_by_doc.get(doc_id),
+            'entities': [
+                entity['name']
+                for entity in entities_by_doc.get(doc_id, [])
+                if entity.get('name') is not None
+            ],
         })
     return jsonify(results)

--- a/web/directions.py
+++ b/web/directions.py
@@ -72,7 +72,8 @@ def equipment():
                     entities_by_doc[doc_id].append({
                         'name': query,
                         'term': term,
-                        'attr': {'class': f'{entity_type} {entity_class}'},
+                        'type': entity_type,
+                        'category': entity_class,
                     })
 
     # Collect unique verbs found in each input description
@@ -83,7 +84,8 @@ def equipment():
             term = next(index.tokenize(verb))
             entities_by_doc[doc_id].append({
                 'term': term,
-                'attr': {'class': 'action'}
+                'type': 'verb',
+                'category': 'action',
             })
 
     # Collect all entities for each document and then generate doc markup
@@ -92,9 +94,15 @@ def equipment():
         terms = []
         term_attributes = {}
         for entity in entities:
-            term, attr = entity['term'], entity['attr']
+            term, entity_type, entity_category = (
+                entity['term'],
+                entity['type'],
+                entity['category'],
+            )
             terms.append(term)
-            term_attributes[term] = attr
+            term_attributes[term] = {
+                'class': f'{entity_type} {entity_category}',
+            }
         markup_by_doc[doc_id] = index.highlight(
             doc=descriptions[doc_id],
             terms=terms,
@@ -109,7 +117,11 @@ def equipment():
             'description': description,
             'markup': markup_by_doc.get(doc_id),
             'entities': [
-                {'name': entity['name']}
+                {
+                    'name': entity['name'],
+                    'type': entity['type'],
+                    'category': entity['category'],
+                }
                 for entity in entities_by_doc.get(doc_id, [])
                 if entity.get('name') is not None
             ],


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
When parsing recipe directions, we include inline markup that indicates entities (like kitchen equipment) that have been discovered during parsing.

These entities may be in singular or plural form.  For search indexing purposes, we generally want to consolidate the representation of items into a single searchable token for each entity - either the plural form, or the singular form.

For ingredients we dynamically select the singular/plural form based on the most popular representation of the ingredient name in web content that we know about.  For equipment, the situation is slightly different since we manually curate a list of equipment names.

This change adds an `entities` field to the direction parsing response that includes the manually-curated equipment name, so that search indexing can use this as a single token that corresponds to each known equipment item.

### Briefly summarize the changes
1. Add an `entities` response field on the direction endpoint
2. Represent each entity in the response field by using a dictionary containing some key properties of the entity

### How have the changes been tested?
1. Local development testing
2. Some unit test coverage is provided

**List any issues that this change relates to**
Relates to #62.