### PR TITLE
Dynamically reload product hierarchy using a cached service call

### DIFF
--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -1,16 +1,11 @@
 from unittest.mock import patch
 
-from web.app import app
 from web.models.product import Product
 
 
 @patch("web.ingredients.retrieve_hierarchy")
 @patch("web.ingredients.retrieve_stopwords")
 def test_ingredient_query(stopwords, hierarchy, client):
-    # HACK: Ensure that app initialization methods (re)run during this test
-    del app.graph
-    del app.graph_loaded_at
-
     stopwords.return_value = []
     hierarchy.return_value = [
         Product(id="onion", name="onion", frequency=10),

--- a/tests/test_ingredients.py
+++ b/tests/test_ingredients.py
@@ -8,7 +8,8 @@ from web.models.product import Product
 @patch("web.ingredients.retrieve_stopwords")
 def test_ingredient_query(stopwords, hierarchy, client):
     # HACK: Ensure that app initialization methods (re)run during this test
-    app._got_first_request = False
+    del app.graph
+    del app.graph_loaded_at
 
     stopwords.return_value = []
     hierarchy.return_value = [

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -21,14 +21,12 @@ def preload_ingredient_data():
     stopwords = retrieve_stopwords(filename)
 
     app.graph = ProductGraph(hierarchy, stopwords)
-    app.products = app.graph.filter_products()
-    app.stopwords = app.graph.filter_stopwords()
 
 
 def find_product_candidates(products):
     queries = [product.name for product in products]
     results = app.graph.product_index.query_batch(
-        queries, stopwords=app.stopwords, query_limit=-1
+        queries, stopwords=app.graph.filter_stopwords(), query_limit=-1
     )
     for description, hits in results:
         for hit in hits:

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -15,14 +15,17 @@ from web.models.product_graph import ProductGraph
 
 @app.before_request
 def preload_ingredient_data():
+    # HACK: Only perform ingredient preloading for the ingredient query URL path
+    if request.path != "/ingredients/query":
+        return
+
     # Return cached product graph if it is available and has not yet expired
     if hasattr(app, "graph"):
         if datetime.utcnow() < app.graph_loaded_at + timedelta(minutes=1):
             return
 
     # Otherwise, attempt to update the product graph
-    filename = CACHE_PATHS["hierarchy"]
-    hierarchy = retrieve_hierarchy(filename)
+    hierarchy = retrieve_hierarchy()
 
     filename = CACHE_PATHS["stopwords"]
     stopwords = retrieve_stopwords(filename)

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -21,7 +21,7 @@ def preload_ingredient_data():
 
     # Return cached product graph if it is available and has not yet expired
     if hasattr(app, "graph"):
-        if datetime.utcnow() < app.graph_loaded_at + timedelta(minutes=1):
+        if datetime.utcnow() < app.graph_loaded_at + timedelta(hours=1):
             return
 
     # Otherwise, attempt to update the product graph

--- a/web/ingredients.py
+++ b/web/ingredients.py
@@ -26,7 +26,7 @@ def preload_ingredient_data():
 def find_product_candidates(products):
     queries = [product.name for product in products]
     results = app.graph.product_index.query_batch(
-        queries, stopwords=app.graph.filter_stopwords(), query_limit=-1
+        queries, stopwords=app.graph.stopwords, query_limit=-1
     )
     for description, hits in results:
         for hit in hits:

--- a/web/loader.py
+++ b/web/loader.py
@@ -1,11 +1,12 @@
 import json
 import os
 
+import requests
+
 from web.models.product import Product
 
 
 CACHE_PATHS = {
-    "hierarchy": "web/data/generated/hierarchy.json",
     "stopwords": "web/data/generated/stopwords.txt",
     "appliance_queries": "web/data/equipment/appliances.txt",
     "utensil_queries": "web/data/equipment/utensils.txt",
@@ -30,19 +31,18 @@ def retrieve_stopwords(filename):
             yield line.strip()
 
 
-def retrieve_hierarchy(filename):
-    if not os.path.exists(filename):
-        raise RuntimeError(f"Could not read hierarchy from: {filename}")
+def retrieve_hierarchy():
+    url = "http://backend-service/products/hierarchy"
+    print(f"Reading hierarchy from {url}")
 
-    print(f"Reading hierarchy from {filename}")
-    with open(filename) as f:
-        for line in f.readlines():
-            if line.startswith("#"):
-                continue
-            product = json.loads(line)
-            yield Product(
-                id=product["id"],
-                name=product["product"],
-                frequency=product["recipe_count"],
-                nutrition=product.get("nutrition"),
-            )
+    text = requests.get(url).content.decode("utf-8")
+    for line in text.splitlines():
+        if line.startswith("#"):
+            continue
+        product = json.loads(line)
+        yield Product(
+            id=product["id"],
+            name=product["product"],
+            frequency=product["recipe_count"],
+            nutrition=product.get("nutrition"),
+        )

--- a/web/loader.py
+++ b/web/loader.py
@@ -37,8 +37,6 @@ def retrieve_hierarchy():
 
     text = requests.get(url).content.decode("utf-8")
     for line in text.splitlines():
-        if line.startswith("#"):
-            continue
         product = json.loads(line)
         yield Product(
             id=product["id"],

--- a/web/models/product_graph.py
+++ b/web/models/product_graph.py
@@ -75,6 +75,3 @@ class ProductGraph(object):
                     product.stopwords.append(self.stopwords[doc_id])
             if self.product_index.tokenize(product.name, product.stopwords):
                 yield product
-
-    def filter_stopwords(self):
-        return self.stopwords


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
After making edits to product data by using the Admin UI presented by the `backend` service, it can be easy to forget to perform the [tedious and manual steps](https://github.com/openculinary/backend/issues/54#issuecomment-1212960993) required to update the product data held within this service.

This change introduces dynamic loading of product data from source, with a 1-hour expiry for that data.

In future we may want to consider migrating the source-of-truth for product data -- and the admin UI -- into this service.  Currently we have a kind of custom-implemented data replication going on here, and we shouldn't really need to invent our own data replication solutions.

### Briefly summarize the changes
1. Make a service call to the `backend` service to preload product data, and cache the results for one hour

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/backend#54.